### PR TITLE
6/7/9: Implement train.py, evaluate.py, inference.py (Phase 2 & 3)

### DIFF
--- a/src/coffee_first_crack/evaluate.py
+++ b/src/coffee_first_crack/evaluate.py
@@ -1,0 +1,209 @@
+"""Evaluate a fine-tuned checkpoint on the test set.
+
+Produces a full metrics report (accuracy, F1, ROC-AUC, per-class
+precision/recall), classification report, and confusion matrix plot.
+
+Usage::
+
+    python -m coffee_first_crack.evaluate \\
+        --model-dir experiments/baseline_v1/checkpoint-best \\
+        --test-dir data/splits/test \\
+        --output-dir experiments/baseline_v1/evaluation
+
+    # Evaluate a HuggingFace Hub checkpoint
+    python -m coffee_first_crack.evaluate \\
+        --model-dir syamaner/coffee-first-crack-detection \\
+        --test-dir data/splits/test
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import seaborn as sns
+import torch
+from torch.utils.data import DataLoader
+from tqdm import tqdm
+from transformers import ASTForAudioClassification, ASTFeatureExtractor
+
+from coffee_first_crack.dataset import FirstCrackDataset
+from coffee_first_crack.model import FirstCrackClassifier, build_feature_extractor
+from coffee_first_crack.utils.device import get_dataloader_kwargs, get_device
+from coffee_first_crack.utils.metrics import MetricsCalculator
+
+
+def evaluate_model(
+    model: FirstCrackClassifier,
+    test_dir: Path,
+    batch_size: int = 8,
+    sample_rate: int = 16000,
+    target_length: int = 10,
+) -> MetricsCalculator:
+    """Run evaluation on the test set.
+
+    Args:
+        model: Loaded ``FirstCrackClassifier`` (already on correct device).
+        test_dir: Directory with ``first_crack/`` and ``no_first_crack/`` subdirs.
+        batch_size: Evaluation batch size.
+        sample_rate: Target sample rate in Hz.
+        target_length: Audio window length in seconds.
+
+    Returns:
+        Populated ``MetricsCalculator`` ready to call ``.compute()``.
+    """
+    dl_kwargs = get_dataloader_kwargs(model.device_str)
+    dataset = FirstCrackDataset(
+        test_dir,
+        sample_rate=sample_rate,
+        target_length=target_length,
+        crop_mode="center",
+    )
+    loader = DataLoader(
+        dataset,
+        batch_size=batch_size,
+        shuffle=False,
+        **dl_kwargs,
+    )
+
+    print(f"\nTest set: {len(dataset)} samples")
+    stats = dataset.get_statistics()
+    print(f"  first_crack:    {stats['first_crack']}")
+    print(f"  no_first_crack: {stats['no_first_crack']}")
+
+    metrics = MetricsCalculator()
+    model.model.eval()
+
+    print("\nEvaluating...")
+    with torch.inference_mode():
+        for audio, labels in tqdm(loader, desc="Testing"):
+            audio = audio.to(model.device_str)
+            labels = labels.to(model.device_str)
+
+            logits = model(audio)
+            probs = torch.softmax(logits, dim=-1)
+            preds = torch.argmax(probs, dim=-1)
+
+            metrics.update(preds, labels, probs)
+
+    return metrics
+
+
+def plot_confusion_matrix(cm: object, output_path: Path) -> None:
+    """Save a labelled confusion matrix heatmap.
+
+    Args:
+        cm: Numpy confusion matrix array.
+        output_path: Where to save the PNG.
+    """
+    plt.figure(figsize=(7, 6))
+    sns.heatmap(
+        cm,
+        annot=True,
+        fmt="d",
+        cmap="Blues",
+        xticklabels=["no_first_crack", "first_crack"],
+        yticklabels=["no_first_crack", "first_crack"],
+    )
+    plt.title("Confusion Matrix — Test Set")
+    plt.ylabel("True Label")
+    plt.xlabel("Predicted Label")
+    plt.tight_layout()
+    plt.savefig(output_path, dpi=150)
+    plt.close()
+    print(f"Confusion matrix saved to {output_path}")
+
+
+def main() -> None:
+    """CLI entry point for evaluation."""
+    parser = argparse.ArgumentParser(description="Evaluate the first crack detection model")
+    parser.add_argument(
+        "--model-dir", type=str, required=True,
+        help="Path to save_pretrained checkpoint dir or HuggingFace model ID",
+    )
+    parser.add_argument(
+        "--test-dir", type=Path, default=Path("data/splits/test"),
+        help="Test set directory (default: data/splits/test)",
+    )
+    parser.add_argument(
+        "--output-dir", type=Path, default=None,
+        help="Directory to save results (default: <model-dir>/evaluation)",
+    )
+    parser.add_argument(
+        "--batch-size", type=int, default=8,
+        help="Evaluation batch size (default: 8)",
+    )
+    args = parser.parse_args()
+
+    if not args.test_dir.exists():
+        print(f"Error: test directory not found: {args.test_dir}")
+        sys.exit(1)
+
+    output_dir = args.output_dir or Path(args.model_dir) / "evaluation"
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    device = get_device()
+    print(f"Device: {device}")
+    print(f"Loading model from: {args.model_dir}")
+
+    model = FirstCrackClassifier(
+        model_name_or_path=args.model_dir,
+        device=device,
+    )
+
+    metrics = evaluate_model(
+        model=model,
+        test_dir=args.test_dir,
+        batch_size=args.batch_size,
+    )
+
+    results = metrics.compute()
+    cm = metrics.compute_confusion_matrix()
+    report = metrics.get_classification_report()
+
+    # Print results
+    sep = "=" * 60
+    print(f"\n{sep}")
+    print("TEST SET RESULTS")
+    print(sep)
+    print(f"Accuracy:              {results['accuracy']:.4f}")
+    print(f"Precision:             {results['precision']:.4f}")
+    print(f"Recall:                {results['recall']:.4f}")
+    print(f"F1:                    {results['f1']:.4f}")
+    if "roc_auc" in results:
+        print(f"ROC-AUC:               {results['roc_auc']:.4f}")
+    print(f"\nFirst-crack recall:    {results['recall_first_crack']:.4f}  ← key metric")
+    print(f"First-crack precision: {results['precision_first_crack']:.4f}")
+    print(f"\n{sep}\nCLASSIFICATION REPORT\n{sep}")
+    print(report)
+    print(f"{sep}\nCONFUSION MATRIX\n{sep}")
+    print(cm)
+
+    # Save text results
+    results_path = output_dir / "test_results.txt"
+    with results_path.open("w") as f:
+        f.write(f"Model: {args.model_dir}\n\n")
+        for k, v in results.items():
+            f.write(f"{k}: {v:.4f}\n")
+        f.write(f"\n{report}\n\nConfusion Matrix:\n{cm}\n")
+    print(f"\nResults saved to {results_path}")
+
+    # Save JSON for programmatic use
+    json_path = output_dir / "test_results.json"
+    with json_path.open("w") as f:
+        json.dump({k: float(v) for k, v in results.items()}, f, indent=2)
+
+    # Save classification report
+    (output_dir / "classification_report.txt").write_text(report)
+
+    # Plot confusion matrix
+    plot_confusion_matrix(cm, output_dir / "confusion_matrix.png")
+
+    print(f"\nAll results saved to {output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/coffee_first_crack/inference.py
+++ b/src/coffee_first_crack/inference.py
@@ -1,0 +1,432 @@
+"""Inference module: sliding window and live microphone first crack detection.
+
+Two main classes:
+- ``SlidingWindowInference`` — offline processing of audio files
+- ``FirstCrackDetector`` — real-time streaming (file or microphone) with
+  thread-safe pop-confirmation logic
+
+Usage::
+
+    # File-based sliding window
+    python -m coffee_first_crack.inference \\
+        --audio data/raw/mic2-brazil-roast1.wav \\
+        --model-dir syamaner/coffee-first-crack-detection
+
+    # Live microphone
+    python -m coffee_first_crack.inference --microphone \\
+        --model-dir syamaner/coffee-first-crack-detection
+
+    # List audio devices
+    python -c "import sounddevice as sd; print(sd.query_devices())"
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import threading
+import time
+from collections import deque
+from dataclasses import dataclass
+from datetime import timedelta
+from pathlib import Path
+from typing import Optional, Union
+
+import librosa
+import numpy as np
+import torch
+
+from coffee_first_crack.model import FirstCrackClassifier
+from coffee_first_crack.utils.device import get_device
+
+
+# ── Detection event ───────────────────────────────────────────────────────────
+
+
+@dataclass
+class DetectionEvent:
+    """A confirmed first-crack detection event.
+
+    Attributes:
+        timestamp_sec: Time (in seconds) of first confirmed pop.
+        timestamp_str: Human-readable ``"MM:SS"`` string.
+        confidence: Number of positive pops within the confirmation window.
+    """
+
+    timestamp_sec: float
+    timestamp_str: str
+    confidence: int
+
+
+def _format_time(seconds: float) -> str:
+    """Format seconds as ``MM:SS``."""
+    total = int(seconds)
+    return f"{total // 60:02d}:{total % 60:02d}"
+
+
+# ── Sliding window (offline) ──────────────────────────────────────────────────
+
+
+class SlidingWindowInference:
+    """Process an audio file with a sliding window and detect first crack.
+
+    Args:
+        model_name_or_path: HuggingFace model ID or local ``save_pretrained`` dir.
+        window_size: Window length in seconds (default: 10.0).
+        overlap: Overlap fraction between consecutive windows (default: 0.7).
+        threshold: Minimum first-crack probability to count as a pop (default: 0.6).
+        min_pops: Number of positive windows required for confirmation (default: 5).
+        confirmation_window: Time span in seconds over which pops are counted (default: 20.0).
+        device: Target device. Defaults to auto-detected.
+    """
+
+    def __init__(
+        self,
+        model_name_or_path: str = "syamaner/coffee-first-crack-detection",
+        window_size: float = 10.0,
+        overlap: float = 0.7,
+        threshold: float = 0.6,
+        min_pops: int = 5,
+        confirmation_window: float = 20.0,
+        device: str | None = None,
+    ) -> None:
+        self.window_size = window_size
+        self.overlap = overlap
+        self.threshold = threshold
+        self.min_pops = min_pops
+        self.confirmation_window = confirmation_window
+        self.device = device or get_device()
+        self.sample_rate = 16000
+        self.window_samples = int(window_size * self.sample_rate)
+        self.hop_samples = int(self.window_samples * (1 - overlap))
+
+        self._model = FirstCrackClassifier(
+            model_name_or_path=model_name_or_path,
+            device=self.device,
+        )
+        self._model.model.eval()
+
+    def process_file(self, audio_path: Union[str, Path]) -> list[DetectionEvent]:
+        """Process an audio file and return confirmed detection events.
+
+        Args:
+            audio_path: Path to the WAV file to process.
+
+        Returns:
+            List of :class:`DetectionEvent` instances (usually 0 or 1).
+        """
+        audio_path = Path(audio_path)
+        audio, _sr = librosa.load(str(audio_path), sr=self.sample_rate, mono=True)
+        duration = len(audio) / self.sample_rate
+        print(f"Processing: {audio_path.name} ({duration:.1f}s)")
+
+        history: list[tuple[float, bool, float]] = []
+        events: list[DetectionEvent] = []
+        confirmed = False
+        start = 0
+
+        while start + self.window_samples <= len(audio):
+            window = audio[start : start + self.window_samples]
+            current_time = start / self.sample_rate
+
+            prob = self._predict_window(window)
+            is_positive = prob >= self.threshold
+            history.append((current_time, is_positive, prob))
+
+            # Count pops within confirmation window
+            cutoff = current_time - self.confirmation_window
+            recent_positives = sum(
+                1 for t, pos, _ in history if t >= cutoff and pos
+            )
+
+            if not confirmed and recent_positives >= self.min_pops:
+                confirmed = True
+                first_t = next(
+                    t for t, pos, _ in history if pos and t >= cutoff
+                )
+                event = DetectionEvent(
+                    timestamp_sec=first_t,
+                    timestamp_str=_format_time(first_t),
+                    confidence=recent_positives,
+                )
+                events.append(event)
+                print(
+                    f"FIRST CRACK detected at {event.timestamp_str} "
+                    f"(confidence: {recent_positives} pops)"
+                )
+
+            start += self.hop_samples
+
+        if not events:
+            print("No first crack detected in file.")
+        return events
+
+    @torch.inference_mode()
+    def _predict_window(self, window: np.ndarray) -> float:
+        """Predict first-crack probability for a single audio window.
+
+        Applies an energy-based noise gate: silent windows return 0.0.
+        """
+        if np.sqrt(np.mean(window ** 2)) < 0.01:
+            return 0.0
+        tensor = torch.FloatTensor(window).unsqueeze(0)
+        logits = self._model(tensor)
+        return torch.softmax(logits, dim=-1)[0, 1].item()
+
+
+# ── Live streaming detector ───────────────────────────────────────────────────
+
+
+class FirstCrackDetector:
+    """Real-time first crack detector for file or microphone input.
+
+    Runs inference in a background thread. Call :meth:`start`, then poll
+    :meth:`is_first_crack` in your roast loop, then :meth:`stop`.
+
+    Args:
+        audio_file: Path to WAV file (mutually exclusive with ``use_microphone``).
+        use_microphone: Stream from the default (or specified) microphone.
+        device_index: Sounddevice device index for microphone input.
+        model_name_or_path: HuggingFace model ID or local checkpoint path.
+        window_size: Window length in seconds.
+        overlap: Overlap fraction.
+        threshold: Positive classification threshold.
+        sample_rate: Audio sample rate (must match model: 16 kHz).
+        min_pops: Pops required within ``confirmation_window`` to confirm.
+        confirmation_window: Time span in seconds for pop counting.
+    """
+
+    def __init__(
+        self,
+        audio_file: Optional[Union[str, Path]] = None,
+        use_microphone: bool = False,
+        device_index: Optional[int] = None,
+        model_name_or_path: str = "syamaner/coffee-first-crack-detection",
+        window_size: float = 10.0,
+        overlap: float = 0.7,
+        threshold: float = 0.6,
+        sample_rate: int = 16000,
+        min_pops: int = 5,
+        confirmation_window: float = 20.0,
+    ) -> None:
+        if audio_file and use_microphone:
+            raise ValueError("Specify either audio_file or use_microphone, not both.")
+        if not audio_file and not use_microphone:
+            raise ValueError("Must specify audio_file or use_microphone.")
+
+        self.audio_file = Path(audio_file) if audio_file else None
+        self.use_microphone = use_microphone
+        self.device_index = device_index
+        self.window_size = window_size
+        self.overlap = overlap
+        self.threshold = threshold
+        self.sample_rate = sample_rate
+        self.min_pops = min_pops
+        self.confirmation_window = confirmation_window
+
+        self.window_samples = int(window_size * sample_rate)
+        self.hop_samples = int(self.window_samples * (1 - overlap))
+
+        device = get_device()
+        self._model = FirstCrackClassifier(
+            model_name_or_path=model_name_or_path,
+            device=device,
+        )
+        self._model.model.eval()
+
+        # State
+        self._running = False
+        self._thread: Optional[threading.Thread] = None
+        self._lock = threading.Lock()
+        self._first_crack_detected = False
+        self._first_crack_time: Optional[float] = None
+        self._start_time: Optional[float] = None
+        self._audio_buffer: deque = deque(maxlen=int(sample_rate * 60))
+        self._detection_history: deque = deque(maxlen=200)
+
+    # ── Public API ────────────────────────────────────────────────────────────
+
+    def start(self) -> None:
+        """Start detection in a background thread."""
+        if self._running:
+            raise RuntimeError("Detector already running.")
+        self._running = True
+        self._start_time = time.time()
+
+        if self.use_microphone:
+            self._thread = threading.Thread(target=self._microphone_loop, daemon=True)
+        else:
+            self._thread = threading.Thread(target=self._file_loop, daemon=True)
+        self._thread.start()
+        print("First crack detector started.")
+
+    def stop(self) -> None:
+        """Stop detection and clean up."""
+        self._running = False
+        if self._thread:
+            self._thread.join(timeout=5.0)
+            self._thread = None
+        self._audio_buffer.clear()
+        self._detection_history.clear()
+        print("First crack detector stopped.")
+
+    def is_first_crack(self) -> Union[bool, tuple[bool, str]]:
+        """Check detection state.
+
+        Returns:
+            ``False`` if not yet detected, or ``(True, "MM:SS")`` when confirmed.
+        """
+        with self._lock:
+            if not self._first_crack_detected:
+                return False
+            return True, _format_time(self._first_crack_time or 0.0)
+
+    def get_elapsed_time(self) -> Optional[str]:
+        """Return elapsed time since :meth:`start` as ``"MM:SS"``."""
+        if self._start_time is None:
+            return None
+        return _format_time(time.time() - self._start_time)
+
+    @property
+    def is_running(self) -> bool:
+        """True while the detector background thread is active."""
+        return self._running
+
+    # ── Internal loops ────────────────────────────────────────────────────────
+
+    def _file_loop(self) -> None:
+        """Background thread: process audio file with sliding window."""
+        try:
+            audio, _ = librosa.load(str(self.audio_file), sr=self.sample_rate, mono=True)
+            start = 0
+            while self._running and start + self.window_samples <= len(audio):
+                window = audio[start : start + self.window_samples]
+                current_time = start / self.sample_rate
+                prob = self._predict_window(window)
+                self._update_state(prob, current_time)
+                start += self.hop_samples
+                time.sleep(0.05)
+        except Exception as exc:
+            print(f"File processing error: {exc}")
+        finally:
+            self._running = False
+
+    def _microphone_loop(self) -> None:
+        """Background thread: stream audio from microphone."""
+        try:
+            import sounddevice as sd  # lazy import — not needed on RPi5 without mic
+
+            def _callback(indata: np.ndarray, _frames: int, _t: object, _status: object) -> None:
+                audio_data = indata[:, 0] if indata.ndim > 1 else indata.flatten()
+                with self._lock:
+                    self._audio_buffer.extend(audio_data)
+
+            stream_kwargs: dict = {
+                "samplerate": self.sample_rate,
+                "channels": 1,
+                "callback": _callback,
+                "blocksize": int(self.sample_rate * 0.5),
+            }
+            if self.device_index is not None:
+                stream_kwargs["device"] = self.device_index
+
+            with sd.InputStream(**stream_kwargs):
+                print(f"Microphone stream active at {self.sample_rate} Hz")
+                while self._running:
+                    with self._lock:
+                        buf_size = len(self._audio_buffer)
+                    if buf_size >= self.window_samples:
+                        with self._lock:
+                            window = np.array(list(self._audio_buffer)[-self.window_samples:])
+                        current_time = time.time() - (self._start_time or time.time())
+                        prob = self._predict_window(window)
+                        self._update_state(prob, current_time)
+                    time.sleep(0.5)
+        except Exception as exc:
+            print(f"Microphone error: {exc}")
+            self._running = False
+
+    @torch.inference_mode()
+    def _predict_window(self, window: np.ndarray) -> float:
+        """Predict first-crack probability with noise gate."""
+        if np.sqrt(np.mean(window ** 2)) < 0.01:
+            return 0.0
+        tensor = torch.FloatTensor(window).unsqueeze(0)
+        logits = self._model(tensor)
+        return torch.softmax(logits, dim=-1)[0, 1].item()
+
+    def _update_state(self, prob: float, current_time: float) -> None:
+        """Update detection history and check confirmation threshold."""
+        with self._lock:
+            is_positive = prob >= self.threshold
+            self._detection_history.append((current_time, is_positive, prob))
+
+            cutoff = current_time - self.confirmation_window
+            recent_positives = sum(
+                1 for t, pos, _ in self._detection_history if t >= cutoff and pos
+            )
+
+            if not self._first_crack_detected and recent_positives >= self.min_pops:
+                self._first_crack_detected = True
+                self._first_crack_time = next(
+                    t for t, pos, _ in self._detection_history if pos and t >= cutoff
+                )
+                print(
+                    f"FIRST CRACK at {_format_time(self._first_crack_time)} "
+                    f"(confidence: {recent_positives} pops)"
+                )
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    """CLI entry point for inference."""
+    parser = argparse.ArgumentParser(description="Coffee first crack inference")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--audio", type=Path, help="Path to audio file")
+    group.add_argument("--microphone", action="store_true", help="Use live microphone")
+    parser.add_argument(
+        "--model-dir", type=str, default="syamaner/coffee-first-crack-detection",
+        help="HuggingFace model ID or local checkpoint directory",
+    )
+    parser.add_argument("--device-index", type=int, default=None, help="Microphone device index")
+    parser.add_argument("--threshold", type=float, default=0.6, help="Detection threshold")
+    args = parser.parse_args()
+
+    if args.microphone:
+        detector = FirstCrackDetector(
+            use_microphone=True,
+            device_index=args.device_index,
+            model_name_or_path=args.model_dir,
+            threshold=args.threshold,
+        )
+    else:
+        if not args.audio.exists():
+            print(f"Error: audio file not found: {args.audio}")
+            sys.exit(1)
+        detector = FirstCrackDetector(
+            audio_file=args.audio,
+            model_name_or_path=args.model_dir,
+            threshold=args.threshold,
+        )
+
+    detector.start()
+    try:
+        while detector.is_running:
+            result = detector.is_first_crack()
+            elapsed = detector.get_elapsed_time()
+            if result is False:
+                print(f"[{elapsed}] Listening...")
+            else:
+                _, ts = result
+                print(f"[{elapsed}] First crack at {ts}!")
+            time.sleep(3)
+    except KeyboardInterrupt:
+        print("\nStopping...")
+    finally:
+        detector.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/coffee_first_crack/train.py
+++ b/src/coffee_first_crack/train.py
@@ -1,0 +1,382 @@
+"""Training script for coffee first crack detection using HuggingFace Trainer API.
+
+Uses a custom ``WeightedLossTrainer`` subclass that overrides ``compute_loss``
+to apply class-weighted CrossEntropyLoss for handling dataset imbalance.
+
+Usage::
+
+    python -m coffee_first_crack.train \\
+        --data-dir data/splits \\
+        --experiment-name baseline_v1
+
+    # With push to HuggingFace Hub after training
+    python -m coffee_first_crack.train \\
+        --data-dir data/splits \\
+        --experiment-name baseline_v1 \\
+        --push-to-hub
+
+    # Resume from a checkpoint directory
+    python -m coffee_first_crack.train \\
+        --data-dir data/splits \\
+        --resume experiments/baseline_v1/checkpoint-best
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+import torch.nn as nn
+import yaml
+from transformers import (
+    ASTForAudioClassification,
+    EarlyStoppingCallback,
+    Trainer,
+    TrainingArguments,
+)
+
+from coffee_first_crack.dataset import FirstCrackDataset, create_dataloaders
+from coffee_first_crack.model import (
+    DEFAULT_BASE_MODEL,
+    build_feature_extractor,
+    build_model,
+)
+from coffee_first_crack.utils.device import get_dataloader_kwargs, get_device
+from coffee_first_crack.utils.metrics import MetricsCalculator
+
+
+# ── Weighted-loss trainer ─────────────────────────────────────────────────────
+
+
+class WeightedLossTrainer(Trainer):
+    """HuggingFace ``Trainer`` subclass with class-weighted CrossEntropyLoss.
+
+    Pass ``class_weights`` as a float tensor of shape ``(num_classes,)``
+    when constructing. The weights are moved to the correct device automatically.
+
+    Args:
+        class_weights: Per-class loss weights. Passed to ``nn.CrossEntropyLoss``.
+        *args: Positional arguments forwarded to ``Trainer``.
+        **kwargs: Keyword arguments forwarded to ``Trainer``.
+    """
+
+    def __init__(
+        self,
+        class_weights: torch.Tensor,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.class_weights = class_weights
+
+    def compute_loss(
+        self,
+        model: ASTForAudioClassification,
+        inputs: dict[str, Any],
+        return_outputs: bool = False,
+        **kwargs: Any,
+    ) -> torch.Tensor | tuple[torch.Tensor, Any]:
+        """Override loss with class-weighted CrossEntropyLoss.
+
+        Args:
+            model: The model being trained.
+            inputs: Batch dict containing ``labels`` and model inputs.
+            return_outputs: If ``True``, also return model outputs.
+
+        Returns:
+            Loss tensor, or ``(loss, outputs)`` if ``return_outputs`` is ``True``.
+        """
+        labels = inputs.pop("labels")
+        outputs = model(**inputs)
+        logits = outputs.logits
+
+        weights = self.class_weights.to(logits.device)
+        loss_fn = nn.CrossEntropyLoss(weight=weights)
+        loss = loss_fn(logits, labels)
+
+        return (loss, outputs) if return_outputs else loss
+
+
+# ── HF Dataset adapter ────────────────────────────────────────────────────────
+
+
+class _HFDatasetAdapter(torch.utils.data.Dataset):
+    """Wraps ``FirstCrackDataset`` to return dicts compatible with HF Trainer.
+
+    The Trainer expects batches with ``input_values`` (or ``input_features``)
+    and ``labels``. We use the ``ASTFeatureExtractor`` to convert raw waveforms
+    to ``input_features`` on-the-fly.
+    """
+
+    def __init__(self, base_dataset: FirstCrackDataset) -> None:
+        self._base = base_dataset
+        self._extractor = build_feature_extractor()
+
+    def __len__(self) -> int:
+        return len(self._base)
+
+    def __getitem__(self, idx: int) -> dict[str, Any]:
+        audio_tensor, label = self._base[idx]
+        audio_list: list[float] = audio_tensor.tolist()
+        inputs = self._extractor(
+            [audio_list],
+            sampling_rate=16000,
+            return_tensors="pt",
+            padding=True,
+        )
+        return {
+            "input_features": inputs["input_features"].squeeze(0),
+            "labels": torch.tensor(label, dtype=torch.long),
+        }
+
+
+# ── compute_metrics callback ──────────────────────────────────────────────────
+
+
+def _make_compute_metrics() -> Any:
+    """Return a ``compute_metrics`` function for the HF Trainer.
+
+    Uses ``MetricsCalculator`` to compute accuracy, F1, precision, recall,
+    and first-crack recall.
+    """
+    import evaluate as hf_evaluate  # lazy import — only needed during training
+
+    accuracy_metric = hf_evaluate.load("accuracy")
+    f1_metric = hf_evaluate.load("f1")
+
+    def compute_metrics(eval_pred: Any) -> dict[str, float]:
+        logits, labels = eval_pred
+        preds = np.argmax(logits, axis=-1)
+        probs = torch.softmax(torch.tensor(logits, dtype=torch.float32), dim=-1).numpy()
+
+        calc = MetricsCalculator()
+        calc.all_preds = preds.tolist()
+        calc.all_labels = labels.tolist()
+        calc.all_probs = probs.tolist()
+        results = calc.compute()
+
+        # Also use HF evaluate for standard metrics
+        acc = accuracy_metric.compute(predictions=preds, references=labels)
+        f1 = f1_metric.compute(predictions=preds, references=labels, average="binary")
+
+        return {
+            "accuracy": acc["accuracy"],
+            "f1": f1["f1"],
+            "precision": results["precision"],
+            "recall": results["recall"],
+            "recall_first_crack": results["recall_first_crack"],
+            "roc_auc": results.get("roc_auc", 0.0),
+        }
+
+    return compute_metrics
+
+
+# ── main training function ────────────────────────────────────────────────────
+
+
+def train(
+    data_dir: Path,
+    experiment_name: str,
+    config_path: Path = Path("configs/default.yaml"),
+    resume_from: Path | None = None,
+    push_to_hub: bool = False,
+    fp16: bool = False,
+    bf16: bool = False,
+) -> Path:
+    """Run the full training pipeline.
+
+    Args:
+        data_dir: Root directory containing ``train/``, ``val/``, ``test/`` splits.
+        experiment_name: Name for the experiment directory under ``experiments/``.
+        config_path: Path to YAML config file.
+        resume_from: Optional path to a checkpoint directory to resume from.
+        push_to_hub: If ``True``, push the final model to HuggingFace Hub.
+        fp16: Enable FP16 mixed precision (CUDA only).
+        bf16: Enable BF16 mixed precision (CUDA only).
+
+    Returns:
+        Path to the best checkpoint directory.
+    """
+    # Load config
+    with config_path.open() as f:
+        cfg = yaml.safe_load(f)
+
+    tc = cfg["training"]
+    ac = cfg["audio"]
+    device = get_device()
+    dl_kwargs = get_dataloader_kwargs(device)
+
+    torch.manual_seed(tc["seed"])
+    np.random.seed(tc["seed"])
+
+    print(f"\nDevice: {device}")
+    print(f"Experiment: {experiment_name}")
+
+    # Paths
+    train_dir = data_dir / "train"
+    val_dir = data_dir / "val"
+    experiment_dir = Path("experiments") / experiment_name
+    experiment_dir.mkdir(parents=True, exist_ok=True)
+
+    # Datasets
+    print("Loading datasets...")
+    train_base = FirstCrackDataset(
+        train_dir,
+        sample_rate=ac["sample_rate"],
+        target_length=ac["target_length_sec"],
+        crop_mode=tc["train_crop_mode"],
+    )
+    val_base = FirstCrackDataset(
+        val_dir,
+        sample_rate=ac["sample_rate"],
+        target_length=ac["target_length_sec"],
+        crop_mode=tc["eval_crop_mode"],
+    )
+    train_stats = train_base.get_statistics()
+    val_stats = val_base.get_statistics()
+    print(
+        f"Train: {train_stats['total_samples']} samples "
+        f"({train_stats['first_crack']} first_crack, "
+        f"{train_stats['no_first_crack']} no_first_crack)"
+    )
+    print(
+        f"Val:   {val_stats['total_samples']} samples "
+        f"({val_stats['first_crack']} first_crack, "
+        f"{val_stats['no_first_crack']} no_first_crack)"
+    )
+
+    class_weights = train_base.get_class_weights()
+    print(f"Class weights: no_first_crack={class_weights[0]:.3f}, first_crack={class_weights[1]:.3f}")
+
+    train_dataset = _HFDatasetAdapter(train_base)
+    val_dataset = _HFDatasetAdapter(val_base)
+
+    # Model
+    print(f"\nLoading base model: {DEFAULT_BASE_MODEL}")
+    model = build_model(device=device)
+
+    feature_extractor = build_feature_extractor()
+
+    # TrainingArguments
+    hub_kwargs: dict[str, Any] = {}
+    if push_to_hub:
+        hub_kwargs = {
+            "push_to_hub": True,
+            "hub_model_id": "syamaner/coffee-first-crack-detection",
+        }
+
+    training_args = TrainingArguments(
+        output_dir=str(experiment_dir),
+        num_train_epochs=tc["num_epochs"],
+        per_device_train_batch_size=tc["batch_size"],
+        per_device_eval_batch_size=tc["batch_size"],
+        learning_rate=tc["learning_rate"],
+        weight_decay=tc["weight_decay"],
+        max_grad_norm=tc["max_grad_norm"],
+        warmup_steps=tc["warmup_steps"],
+        eval_strategy=tc["evaluation_strategy"],
+        save_strategy=tc["save_strategy"],
+        load_best_model_at_end=tc["load_best_model_at_end"],
+        metric_for_best_model=tc["metric_for_best_model"],
+        greater_is_better=True,
+        logging_dir=str(experiment_dir / "logs"),
+        logging_steps=10,
+        save_total_limit=3,
+        fp16=fp16 and device == "cuda",
+        bf16=bf16 and device == "cuda",
+        dataloader_num_workers=dl_kwargs["num_workers"],
+        seed=tc["seed"],
+        report_to=["tensorboard"],
+        **hub_kwargs,
+    )
+
+    trainer = WeightedLossTrainer(
+        class_weights=class_weights,
+        model=model,
+        args=training_args,
+        train_dataset=train_dataset,
+        eval_dataset=val_dataset,
+        processing_class=feature_extractor,
+        compute_metrics=_make_compute_metrics(),
+        callbacks=[
+            EarlyStoppingCallback(
+                early_stopping_patience=tc["early_stopping_patience"]
+            )
+        ],
+    )
+
+    # Train
+    print("\nStarting training...\n")
+    if resume_from:
+        trainer.train(resume_from_checkpoint=str(resume_from))
+    else:
+        trainer.train()
+
+    # Save best model using HF save_pretrained
+    best_dir = experiment_dir / "checkpoint-best"
+    trainer.save_model(str(best_dir))
+    feature_extractor.save_pretrained(str(best_dir))
+    print(f"\nBest model saved to: {best_dir}")
+
+    if push_to_hub:
+        trainer.push_to_hub()
+        print("Model pushed to HuggingFace Hub")
+
+    return best_dir
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    """CLI entry point for training."""
+    parser = argparse.ArgumentParser(description="Train the coffee first crack detection model")
+    parser.add_argument(
+        "--data-dir", type=Path, default=Path("data/splits"),
+        help="Directory containing train/val/test splits (default: data/splits)",
+    )
+    parser.add_argument(
+        "--experiment-name", type=str, default=None,
+        help="Experiment name (default: exp_YYYYMMDD_HHMMSS)",
+    )
+    parser.add_argument(
+        "--config", type=Path, default=Path("configs/default.yaml"),
+        help="Path to YAML config (default: configs/default.yaml)",
+    )
+    parser.add_argument(
+        "--resume", type=Path, default=None,
+        help="Resume from checkpoint directory",
+    )
+    parser.add_argument(
+        "--push-to-hub", action="store_true",
+        help="Push model to HuggingFace Hub after training",
+    )
+    parser.add_argument("--fp16", action="store_true", help="Enable FP16 (CUDA only)")
+    parser.add_argument("--bf16", action="store_true", help="Enable BF16 (CUDA only)")
+    args = parser.parse_args()
+
+    if not (args.data_dir / "train").exists():
+        print(f"Error: train split not found under {args.data_dir}")
+        print("Run data preparation first — see docs/data_preparation.md")
+        sys.exit(1)
+
+    experiment_name = args.experiment_name or f"exp_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+
+    train(
+        data_dir=args.data_dir,
+        experiment_name=experiment_name,
+        config_path=args.config,
+        resume_from=args.resume,
+        push_to_hub=args.push_to_hub,
+        fp16=args.fp16,
+        bf16=args.bf16,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Implements Phase 2 (Training & Evaluation) and Phase 3 inference core.

## Stories
- Closes #6 (S5: train.py with HF Trainer)
- Closes #7 (S6: evaluate.py with full metrics)
- Closes #9 (S8: inference.py sliding window + streaming detector)
- Part of #1

## Changes

### train.py
- `WeightedLossTrainer` subclasses HF `Trainer`, overrides `compute_loss()` with class-weighted CrossEntropyLoss
- `_HFDatasetAdapter` wraps `FirstCrackDataset` → HF Trainer-compatible dicts with `input_features`
- `TrainingArguments` loaded from `configs/default.yaml` (fp16/bf16, early stopping, push_to_hub)
- `compute_metrics` reports accuracy, F1, precision, recall, recall_first_crack, ROC-AUC
- CLI: `python -m coffee_first_crack.train --data-dir data/splits --experiment-name baseline_v1`

### evaluate.py
- Loads model via `from_pretrained()` (local dir or HF Hub ID)
- Runs `FirstCrackClassifier` over test DataLoader
- Saves `test_results.txt`, `test_results.json`, `classification_report.txt`, `confusion_matrix.png`

### inference.py
- `SlidingWindowInference` — offline file processing, returns `List[DetectionEvent]`
- `FirstCrackDetector` — thread-safe streaming detector (file or microphone)
- Pop-confirmation logic: `min_pops` within `confirmation_window` seconds
- Energy-based noise gate (RMS < 0.01 skips inference)
- `sounddevice` lazily imported (not required on RPi5)