### PR TITLE
docs: add Part 1 series post link to model card, dataset card and Gradio Space

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,11 @@ An Audio Spectrogram Transformer (AST) fine-tuned to detect **first crack** — 
 
 > **Source code & training**: [github.com/syamaner/coffee-first-crack-detection](https://github.com/syamaner/coffee-first-crack-detection)
 >
-> **Original prototype series (the earlier end-to-end build that led to this rewrite):**
+> **How this was built:**
+> - Part 1 — [The Architecture & The Agent — Spec-Driven ML Development with Warp/Oz](https://dev.to/syamaner/part-1-the-architecture-the-agent-spec-driven-ml-development-with-warpoz-3al6)
+>
+> **Original prototype:**
 > - Part 1 — [Training a Neural Network to Detect Coffee First Crack from Audio](https://dev.to/syamaner/part-1-training-a-neural-network-to-detect-coffee-first-crack-from-audio-an-agentic-development-1jei)
-> - Part 2 — [Building MCP Servers to Control a Home Coffee Roaster](https://dev.to/syamaner/part-2-building-mcp-servers-to-control-a-home-coffee-roaster-an-agentic-development-journey-with-58ik)
-> - Part 3 — [From Neural Networks to Autonomous Coffee Roasting: Orchestrating MCP Servers](https://dev.to/syamaner/part-3-from-neural-networks-to-autonomous-coffee-roasting-orchestrating-mcp-servers-with-net-58pd)
 
 ---
 

--- a/data/DATASET_CARD.md
+++ b/data/DATASET_CARD.md
@@ -43,10 +43,11 @@ Audio dataset for training coffee first crack detection models. Contains 10-seco
 > **Model**: [syamaner/coffee-first-crack-detection](https://huggingface.co/syamaner/coffee-first-crack-detection)
 > **Source code**: [github.com/syamaner/coffee-first-crack-detection](https://github.com/syamaner/coffee-first-crack-detection)
 >
-> **Original prototype series (the earlier end-to-end build that led to this rewrite):**
+> **How this was built:**
+> - Part 1 — [The Architecture & The Agent — Spec-Driven ML Development with Warp/Oz](https://dev.to/syamaner/part-1-the-architecture-the-agent-spec-driven-ml-development-with-warpoz-3al6)
+>
+> **Original prototype:**
 > - Part 1 — [Training a Neural Network to Detect Coffee First Crack from Audio](https://dev.to/syamaner/part-1-training-a-neural-network-to-detect-coffee-first-crack-from-audio-an-agentic-development-1jei)
-> - Part 2 — [Building MCP Servers to Control a Home Coffee Roaster](https://dev.to/syamaner/part-2-building-mcp-servers-to-control-a-home-coffee-roaster-an-agentic-development-journey-with-58ik)
-> - Part 3 — [From Neural Networks to Autonomous Coffee Roasting: Orchestrating MCP Servers](https://dev.to/syamaner/part-3-from-neural-networks-to-autonomous-coffee-roasting-orchestrating-mcp-servers-with-net-58pd)
 
 ## Dataset Summary
 

--- a/spaces/README.md
+++ b/spaces/README.md
@@ -19,10 +19,11 @@ Upload a 10-second coffee roasting audio clip to detect **first crack** — the 
 **Model**: [syamaner/coffee-first-crack-detection](https://huggingface.co/syamaner/coffee-first-crack-detection)
 **Code**: [github.com/syamaner/coffee-first-crack-detection](https://github.com/syamaner/coffee-first-crack-detection)
 
-> **Original prototype series (the earlier end-to-end build that led to this rewrite):**
+> **How this was built:**
+> - Part 1 — [The Architecture & The Agent — Spec-Driven ML Development with Warp/Oz](https://dev.to/syamaner/part-1-the-architecture-the-agent-spec-driven-ml-development-with-warpoz-3al6)
+>
+> **Original prototype:**
 > - Part 1 — [Training a Neural Network to Detect Coffee First Crack from Audio](https://dev.to/syamaner/part-1-training-a-neural-network-to-detect-coffee-first-crack-from-audio-an-agentic-development-1jei)
-> - Part 2 — [Building MCP Servers to Control a Home Coffee Roaster](https://dev.to/syamaner/part-2-building-mcp-servers-to-control-a-home-coffee-roaster-an-agentic-development-journey-with-58ik)
-> - Part 3 — [From Neural Networks to Autonomous Coffee Roasting: Orchestrating MCP Servers](https://dev.to/syamaner/part-3-from-neural-networks-to-autonomous-coffee-roasting-orchestrating-mcp-servers-with-net-58pd)
 
 ## How it works
 

--- a/spaces/app.py
+++ b/spaces/app.py
@@ -80,10 +80,11 @@ The model is an Audio Spectrogram Transformer (AST) fine-tuned on 1,435 labelled
 
 Model: [syamaner/coffee-first-crack-detection](https://huggingface.co/syamaner/coffee-first-crack-detection)
 
-**Original prototype series (the earlier end-to-end build that led to this rewrite):**
+**How this was built:**
+- Part 1 — [The Architecture & The Agent — Spec-Driven ML Development with Warp/Oz](https://dev.to/syamaner/part-1-the-architecture-the-agent-spec-driven-ml-development-with-warpoz-3al6)
+
+**Original prototype:**
 - Part 1 — [Training a Neural Network to Detect Coffee First Crack from Audio](https://dev.to/syamaner/part-1-training-a-neural-network-to-detect-coffee-first-crack-from-audio-an-agentic-development-1jei)
-- Part 2 — [Building MCP Servers to Control a Home Coffee Roaster](https://dev.to/syamaner/part-2-building-mcp-servers-to-control-a-home-coffee-roaster-an-agentic-development-journey-with-58ik)
-- Part 3 — [From Neural Networks to Autonomous Coffee Roasting: Orchestrating MCP Servers](https://dev.to/syamaner/part-3-from-neural-networks-to-autonomous-coffee-roasting-orchestrating-mcp-servers-with-net-58pd)
 """
 
 


### PR DESCRIPTION
## Summary

Adds the newly published dev.to Part 1 post to all HuggingFace Hub cards and the Gradio Space description.

### Changes
- Added **'How this was built'** section linking to [Part 1: The Architecture & The Agent](https://dev.to/syamaner/part-1-the-architecture-the-agent-spec-driven-ml-development-with-warpoz-3al6)
- Trimmed prototype series references to Part 1 only (removed Parts 2 and 3)
- Updated: `README.md`, `data/DATASET_CARD.md`, `spaces/README.md`, `spaces/app.py`

Co-Authored-By: Oz <oz-agent@warp.dev>