### PR TITLE
ci(#57): add GitHub Actions CI (gates + torch-free-import guard)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,156 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  # Full-dependency test suite (the repo's own gate today: pytest only — see
+  # the note below on ruff/pyright). Installs the `all` extra (train + export +
+  # dev + inference, i.e. torch/transformers included) because dataset.py,
+  # inference.py, model.py etc. import torch at module scope and the test
+  # suite exercises them directly.
+  test:
+    name: Test (pytest)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      # sounddevice (the `inference` extra, imported by scripts/record_mics.py
+      # and its test) needs the PortAudio runtime library at import time, even
+      # though CI never opens a real audio device. Without it, test collection
+      # fails with "OSError: PortAudio library not found" (verified on a clean
+      # ubuntu-latest-equivalent container).
+      - name: Install system libraries (PortAudio for sounddevice)
+        run: sudo apt-get update && sudo apt-get install -y libportaudio2
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[all]"
+
+      - name: Run tests with coverage
+        run: python -m pytest --cov-report=term-missing:skip-covered
+
+      # NOTE (#57): `ruff check .`, `ruff format --check .`, and `pyright` all
+      # currently fail on `main` (28 ruff lint errors, 9 files needing
+      # `ruff format`, 27 pyright errors — verified 7 Jul 2026, before this
+      # workflow was added). Wiring them here would open this PR red, which
+      # the issue explicitly says not to do. pytest is the one gate the repo
+      # actually passes today (144 passed), so it is the only one wired as a
+      # blocking job. Follow-up: clean up lint/format/typecheck on `main` (own
+      # PR — this one is CI config only) and then add those as gates too.
+
+  # The torch-free import gate (#57 headline). Installs ONLY requirements-pi.txt
+  # (no torch, no transformers — the Raspberry Pi 5 dependency set, D27 Phase 1)
+  # plus the package itself with --no-deps (so installing the package doesn't
+  # pull pyproject.toml's core `dependencies`, which include torch). Then
+  # asserts inference_onnx (and the modules it depends on: events, mel_frontend)
+  # import cleanly AND that the import never pulled torch/transformers into
+  # sys.modules, plus a hermetic (no network, no fixtures) MelFrontend forward
+  # pass to prove the ONNX/mel path actually runs, not just imports.
+  #
+  # This is exactly the gate that would have caught the #56 review blocker:
+  # `__init__.py` used to eagerly import the torch-dependent submodules, so
+  # `import coffee_first_crack.inference_onnx` raised ModuleNotFoundError on a
+  # torch-free interpreter. D27 Phase 1 (#56) fixed this with lazy __getattr__
+  # imports in __init__.py; this job is the regression guard.
+  torch-free-import:
+    name: Torch-free import gate (Raspberry Pi 5 deps)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install Raspberry Pi (torch-free) dependencies only
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-pi.txt
+          # --no-deps: install only the package's own code onto the path.
+          # Installing with full deps would resolve pyproject.toml's core
+          # `dependencies` list, which includes torch — defeating the point
+          # of this job.
+          python -m pip install -e . --no-deps
+
+      - name: Assert torch and transformers are not installed
+        run: |
+          python -c "
+          import importlib.util
+          for pkg in ('torch', 'transformers'):
+              assert importlib.util.find_spec(pkg) is None, f'{pkg} must not be installed in this job'
+          print('Confirmed: torch and transformers are absent from this interpreter.')
+          "
+
+      - name: Import the ONNX inference entrypoint torch-free
+        run: |
+          python -c "
+          import sys
+
+          import coffee_first_crack.events
+          import coffee_first_crack.mel_frontend
+          import coffee_first_crack.inference_onnx as m
+
+          leaked = sorted(
+              mod for mod in sys.modules
+              if mod.split('.')[0] in ('torch', 'transformers')
+          )
+          assert not leaked, f'torch/transformers imported transitively: {leaked}'
+
+          assert hasattr(m, 'OnnxSlidingWindowInference')
+          assert hasattr(m, 'OnnxFirstCrackDetector')
+          print('OK: coffee_first_crack.inference_onnx imports torch-free.')
+          "
+
+      - name: Run a hermetic torch-free mel-frontend forward pass
+        # No network, no HF download, no fixtures: constructs MelFrontend
+        # directly (bypassing from_config's HF-published preprocessor_config.json)
+        # so the smoke stays fast and deterministic while still exercising the
+        # real numpy/scipy feature-extraction path end to end.
+        run: |
+          python -c "
+          import sys
+
+          import numpy as np
+
+          from coffee_first_crack.mel_frontend import MelFrontend
+
+          frontend = MelFrontend(
+              mean=-4.2677393,
+              std=4.5689974,
+              num_mel_bins=128,
+              sampling_rate=16000,
+              max_length=1024,
+          )
+          window = (np.random.randn(160_000) * 0.05).astype(np.float32)
+          out = frontend.extract(window)
+          assert out.shape == (1024, 128), out.shape
+          assert out.dtype == np.float32
+
+          leaked = sorted(
+              mod for mod in sys.modules
+              if mod.split('.')[0] in ('torch', 'transformers')
+          )
+          assert not leaked, f'torch/transformers imported transitively: {leaked}'
+          print('OK: MelFrontend forward pass ran torch-free.')
+          "

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,6 +143,28 @@ pyright src/
 
 ---
 
+## Continuous Integration
+
+`.github/workflows/ci.yml` runs on every push and pull request:
+
+- **`test`** — installs `.[all]` (torch/transformers included) and runs
+  `pytest` with coverage. This is currently the only *blocking* gate: as of
+  the CI being added (#57), `ruff check`, `ruff format --check`, and `pyright`
+  all fail on pre-existing `main` content, so they are not wired as required
+  jobs yet (a red gate the code doesn't pass is worse than no gate — see the
+  in-file comment). Clean those up in a follow-up PR, then add them here.
+- **`torch-free-import`** — the load-bearing gate #57 exists for. Installs
+  only `requirements-pi.txt` (the Raspberry Pi 5 / torch-free dependency set,
+  D27 Phase 1) plus the package with `--no-deps`, then asserts
+  `coffee_first_crack.inference_onnx` (and `events`, `mel_frontend`) import
+  cleanly with torch/transformers absent from `sys.modules`, plus a hermetic
+  `MelFrontend` forward-pass smoke (no network, no fixtures). This is the
+  regression guard for the #56 review blocker, where `__init__.py` eagerly
+  imported torch-dependent submodules and broke `inference_onnx` on a
+  torch-free Pi interpreter.
+
+---
+
 ## Codebase Architecture
 
 ```


### PR DESCRIPTION
## Summary

This repo had **zero CI** — no lint, no type-check, no tests ran on PRs. That's why the D27 Phase 1 torch-free-import blocker (#56) reached review instead of failing a build: `inference_onnx.py` raised `ModuleNotFoundError` on a torch-free interpreter because `__init__.py` eagerly imported torch-dependent submodules.

Adds `.github/workflows/ci.yml` with two jobs, both verified green locally before opening:

- **`test`** — installs `.[all]` (torch/transformers included, matching how the full test suite exercises `dataset.py`/`model.py`/`inference.py`) and runs `pytest` with coverage. 144 passed.
- **`torch-free-import`** — the headline gate this issue exists for. Installs *only* `requirements-pi.txt` (the Raspberry Pi 5 / torch-free set, D27 Phase 1) plus the package via `--no-deps`, then asserts:
  - `torch`/`transformers` are genuinely absent (`importlib.util.find_spec` is `None`)
  - `coffee_first_crack.inference_onnx` (plus `events`, `mel_frontend`) import cleanly, and the import never pulled `torch`/`transformers` into `sys.modules`
  - a hermetic (no network, no fixtures) `MelFrontend` forward pass actually runs on the torch-free interpreter, not just imports

This is exactly the guard that would have caught #56's blocker.

## What did NOT get wired as a blocking gate — and why

Verified locally (in a clean `python:3.11-slim` container, matching what `ubuntu-latest` + `actions/setup-python` gives) that **`ruff check`, `ruff format --check`, and `pyright` all currently fail on `main`**, independent of this PR:

- `ruff check .` → 28 errors (I001 unsorted imports ×7, B905 zip-without-strict ×6, ANN401 any-type ×5, F401 unused-import ×4, E402 ×3, E501 ×2, UP035 ×1)
- `ruff format --check .` → 9 files would be reformatted
- `pyright` → 27 errors (mostly real type issues in `train.py`, `utils/metrics.py`, `inference.py` — once pointed at the right interpreter so imports resolve)

Per the task constraints, I did not add these as gates (that would open this CI-only PR red) and did not fix them here (that's app-code cleanup, a separate PR — this one is CI config only). Documented as a follow-up in `AGENTS.md`'s new "Continuous Integration" section and in an inline workflow comment.

## Test plan

- [x] `test` job commands verified in a clean container: `pip install -e ".[all]"` + `libportaudio2` (needed for `sounddevice`, same gotcha as the sibling `roastpilot-agent` CI) + `pytest --cov-report=term-missing:skip-covered` → 144 passed
- [x] `torch-free-import` job commands verified in a separate clean container: `pip install -r requirements-pi.txt` + `pip install -e . --no-deps` → `torch`/`transformers` confirmed absent, `inference_onnx` imports clean, hermetic `MelFrontend.extract()` forward pass runs, shape `(1024, 128)`
- [ ] This PR's own CI run is the live validation — both jobs should be green

Refs #57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)