### PR TITLE
ci(#34): add HuggingFace card/Space sync workflow (secret-gated, path-filtered)

### DIFF
--- a/.github/workflows/sync-hf.yml
+++ b/.github/workflows/sync-hf.yml
@@ -1,0 +1,149 @@
+# Sync the model card, dataset card, and Space files to HuggingFace Hub.
+#
+# INERT UNTIL CONFIGURED: this workflow requires the `HF_TOKEN` repository
+# secret (a HuggingFace write token). Until an operator (a human) adds that
+# secret, the very first step below detects its absence, logs a clear
+# message, and exits 0 (green) without attempting any upload. No HF repo is
+# touched, no push happens, and CI never goes red because the secret is
+# missing — see the "check-secret" step in the `sync` job.
+#
+# Required secret:
+#   HF_TOKEN — a HuggingFace access token with WRITE scope to all three of
+#   the repos below:
+#     - syamaner/coffee-first-crack-detection   (model repo, also hosts the Space)
+#     - syamaner/coffee-first-crack-audio       (dataset repo)
+#     - syamaner/coffee-first-crack-detection   (space repo, repo_type=space —
+#       same repo id as the model repo, distinguished on HF by repo_type)
+#
+# Source -> destination mapping (from issue #34):
+#
+#   | Source file(s)          | HF repo                                  | repo_type | Destination path |
+#   |--------------------------|------------------------------------------|-----------|-------------------|
+#   | README.md                | syamaner/coffee-first-crack-detection     | model     | README.md         |
+#   | data/DATASET_CARD.md      | syamaner/coffee-first-crack-audio         | dataset   | README.md (renamed) |
+#   | spaces/app.py             | syamaner/coffee-first-crack-detection     | space     | app.py            |
+#   | spaces/README.md          | syamaner/coffee-first-crack-detection     | space     | README.md         |
+#   | spaces/requirements.txt   | syamaner/coffee-first-crack-detection     | space     | requirements.txt  |
+#
+# Uploads use `huggingface_hub.HfApi().upload_file(...)`, which is naturally
+# idempotent: HF only creates a new commit on the target repo when the
+# uploaded content actually differs from what's already there, so re-running
+# this workflow with unchanged files is a safe no-op.
+#
+# To enable auto-sync: add the `HF_TOKEN` repository secret. No other change
+# is required — this workflow does nothing until that secret exists.
+
+name: Sync HuggingFace cards and Space
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "README.md"
+      - "data/DATASET_CARD.md"
+      - "spaces/**"
+
+concurrency:
+  group: sync-hf-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Sync HF cards and Space
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check for HF_TOKEN secret
+        id: check-secret
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          if [ -z "$HF_TOKEN" ]; then
+            echo "HF_TOKEN not configured; skipping sync"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "HF_TOKEN found; proceeding with sync"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check out repository
+        if: steps.check-secret.outputs.skip != 'true'
+        uses: actions/checkout@v6.0.2
+
+      - name: Set up Python
+        if: steps.check-secret.outputs.skip != 'true'
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install huggingface_hub
+        if: steps.check-secret.outputs.skip != 'true'
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "huggingface_hub>=0.20.0,<1.0" "pyyaml>=6.0"
+
+      - name: Validate model card frontmatter
+        if: steps.check-secret.outputs.skip != 'true'
+        run: |
+          python -c "
+          from pathlib import Path
+
+          import yaml
+
+          readme = Path('README.md')
+          content = readme.read_text()
+          if not content.startswith('---'):
+              raise ValueError(\"README.md is missing YAML frontmatter (expected '---' at start)\")
+
+          parts = content.split('---', 2)
+          if len(parts) < 3:
+              raise ValueError(\"README.md frontmatter is malformed (missing closing '---')\")
+
+          metadata = yaml.safe_load(parts[1])
+          required = {'pipeline_tag', 'license', 'base_model'}
+          missing = required - set(metadata or {})
+          if missing:
+              raise ValueError(f'README.md frontmatter missing required fields: {missing}')
+
+          print('Model card YAML frontmatter is valid.')
+          "
+
+      - name: Sync cards and Space files to HuggingFace Hub
+        if: steps.check-secret.outputs.skip != 'true'
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          python -c "
+          import os
+
+          from huggingface_hub import HfApi
+
+          token = os.environ['HF_TOKEN']
+          api = HfApi(token=token)
+
+          # (local path, repo_id, repo_type, path_in_repo)
+          uploads = [
+              ('README.md', 'syamaner/coffee-first-crack-detection', 'model', 'README.md'),
+              ('data/DATASET_CARD.md', 'syamaner/coffee-first-crack-audio', 'dataset', 'README.md'),
+              ('spaces/app.py', 'syamaner/coffee-first-crack-detection', 'space', 'app.py'),
+              ('spaces/README.md', 'syamaner/coffee-first-crack-detection', 'space', 'README.md'),
+              ('spaces/requirements.txt', 'syamaner/coffee-first-crack-detection', 'space', 'requirements.txt'),
+          ]
+
+          for local_path, repo_id, repo_type, path_in_repo in uploads:
+              print(f'Uploading {local_path} -> {repo_id} ({repo_type}) as {path_in_repo}')
+              api.upload_file(
+                  path_or_fileobj=local_path,
+                  path_in_repo=path_in_repo,
+                  repo_id=repo_id,
+                  repo_type=repo_type,
+                  token=token,
+              )
+          print('Sync complete.')
+          "
+
+      - name: Sync skipped
+        if: steps.check-secret.outputs.skip == 'true'
+        run: echo "HF_TOKEN not configured; skipping sync (this is expected until the operator adds the secret)."


### PR DESCRIPTION
## ⚠️ Inert until configured

**This workflow does NOT auto-publish anything until an operator adds the `HF_TOKEN` repository secret.** Merging this PR to `main` will:
- **not** fail CI,
- **not** attempt any HuggingFace upload,
- **not** touch any of the three HF repos below,

because the very first step checks whether `secrets.HF_TOKEN` is set and, if it is empty, logs `HF_TOKEN not configured; skipping sync` and exits 0 (green). All later steps (checkout, install, upload) are gated behind that check and simply don't run.

**To enable auto-sync:** add the `HF_TOKEN` repository secret (a HuggingFace token with write access to all three repos below). No other action is required.

## Summary

Closes #34. Adds `.github/workflows/sync-hf.yml`, a single workflow that syncs the model card, dataset card, and Space files to their HuggingFace repos whenever they change on `main` (or on manual `workflow_dispatch`).

### Mapping (from issue #34)

| Source file(s) | HF repo | repo_type | Destination |
|---|---|---|---|
| `README.md` | `syamaner/coffee-first-crack-detection` | model | `README.md` |
| `data/DATASET_CARD.md` | `syamaner/coffee-first-crack-audio` | dataset | `README.md` (renamed) |
| `spaces/app.py` | `syamaner/coffee-first-crack-detection` | space | `app.py` |
| `spaces/README.md` | `syamaner/coffee-first-crack-detection` | space | `README.md` |
| `spaces/requirements.txt` | `syamaner/coffee-first-crack-detection` | space | `requirements.txt` |

Uploads use `HfApi().upload_file(...)`, which only creates a new commit on the HF side when content actually differs — safe to re-run.

### Skip-guard mechanism

A `check-secret` step runs first, with `HF_TOKEN` injected via `env:` (not referenced directly in an `if:` at the job level):

```yaml
- name: Check for HF_TOKEN secret
  id: check-secret
  env:
    HF_TOKEN: ${{ secrets.HF_TOKEN }}
  run: |
    if [ -z "$HF_TOKEN" ]; then
      echo "HF_TOKEN not configured; skipping sync"
      echo "skip=true" >> "$GITHUB_OUTPUT"
    else
      echo "HF_TOKEN found; proceeding with sync"
      echo "skip=false" >> "$GITHUB_OUTPUT"
    fi
```

Every subsequent step (checkout, setup-python, install, model-card validation, upload) carries `if: steps.check-secret.outputs.skip != 'true'`, so with no secret configured the job still completes successfully (green), it just no-ops after the first step.

### Triggers

- `workflow_dispatch` (manual, no inputs)
- `push` to `main`, filtered to exactly the mapped source paths:
  - `README.md`
  - `data/DATASET_CARD.md`
  - `spaces/**`

### Conventions matched

- `actions/checkout@v6.0.2` and `actions/setup-python@v6.2.0` — same pins as `.github/workflows/ci.yml`
- Python 3.11, `cache: "pip"` — same as `ci.yml`
- `huggingface_hub>=0.20.0,<1.0` — matches the `huggingface-hub>=0.20.0` pin already in `pyproject.toml` / `requirements.txt` / `requirements-pi.txt`
- Reuses the same model-card frontmatter validation logic as `scripts/push_to_hub.py:_validate_model_card`

### Validation performed

- `actionlint .github/workflows/sync-hf.yml` → 0 findings
- `python3 -c "import yaml; yaml.safe_load(...)"` → parses cleanly
- Manual read-through against GH Actions schema (top-level `name`/`on`/`jobs`, `runs-on`, `if:` expression syntax, `${{ }}` expressions)
- **Not performed (by design, per scope):** no workflow run/trigger, no `HF_TOKEN` secret added, no push to any HuggingFace repo

## Test plan

- [x] `actionlint` clean
- [x] YAML parses via `yaml.safe_load`
- [ ] Operator adds `HF_TOKEN` secret with write access to `syamaner/coffee-first-crack-detection` (model + space) and `syamaner/coffee-first-crack-audio` (dataset), then confirms a manual `workflow_dispatch` run succeeds