### PR TITLE
feat: RF+MFCC comparator baseline for first-crack detection

### DIFF
--- a/results/rf_mfcc_baseline/PROTOCOL.md
+++ b/results/rf_mfcc_baseline/PROTOCOL.md
@@ -1,0 +1,81 @@
+# RF + MFCC comparator — pre-registered protocol
+
+Written and committed to disk **before** the training/eval script has been run against the
+test set. This file's content is not edited after seeing test-set results; findings go in
+a separate `RESULTS.md` written after the run.
+
+## Purpose
+
+A classical, non-transformer comparator for the AST-based first-crack detector, per the
+Shi et al. 2026 reference point (Applied Food Research 6(1):102058 — RF on MFCC features,
+~95.7% accuracy / 0.992 AUC on their own data, not directly comparable since it's a
+different dataset). This is a same-data head-to-head against our AST int8 model, not an
+attempt to reproduce their paper's numbers.
+
+## Data
+
+- **Train**: `data/splits/train/` (922 chunks: 136 `first_crack` / 786 `no_first_crack`,
+  21 recordings' worth minus val/test, recording-level split, seed=42 — same split the AST
+  model trains on).
+- **Test**: `data/splits/test/` (303 chunks: 42 `first_crack` / 261 `no_first_crack`) — the
+  same 303-sample set used for every other comparator in this repo. Used ONLY for final
+  evaluation, never for feature selection or hyperparameter choice.
+- `data/splits/val/` is available but not used — see hyperparameter policy below (no tuning
+  loop that would need it).
+- No data augmentation (the repo's amplitude-scaling/noise augmentation is AST-training
+  specific and not applied here — RF gets the raw chunked audio, mirroring what the
+  comparator paper would plausibly do with a fixed feature set).
+
+## Features
+
+Standard MFCCs via `librosa.feature.mfcc`, not the Kaldi-compatible `MelFrontend` the AST
+torch-free path needed — this is a comparator baseline, not a from-scratch numerical
+equivalence target, so librosa's standard implementation is the appropriate and simpler
+choice per the task brief.
+
+- Sample rate: 16000 Hz (matches `SAMPLE_RATE` used throughout the repo)
+- `n_mfcc=20` (a conventional default for speech/audio classification; not tuned)
+- `n_fft=2048`, `hop_length=512` (librosa defaults)
+- Per-clip feature vector: mean + standard deviation of each MFCC coefficient across time
+  frames (a standard fixed-length summarisation for a fixed-length classifier input) → 40
+  features per 10s clip (20 mean + 20 std)
+- No delta / delta-delta MFCCs, no additional spectral features — keeping the feature set
+  minimal and standard, consistent with "does not need the Kaldi-fbank equivalence" framing
+  in the task brief
+
+## Model
+
+- `sklearn.ensemble.RandomForestClassifier`
+- **Hyperparameter policy: default sklearn RF parameters, no tuning.** The repo has no
+  existing RF-tuning convention to follow, and the task brief specifies "default sklearn RF
+  unless the repo has a tuning convention" — it doesn't, so defaults it is
+  (`n_estimators=100`, `criterion="gini"`, no max_depth cap, etc., i.e. whatever
+  `RandomForestClassifier()` gives out of the box in the pinned scikit-learn version).
+- One exception: `random_state=42` (repo seed convention, `configs/default.yaml`) and
+  `class_weight="balanced"` — the training split is imbalanced (136:786, ~15% positive) and
+  leaving RF unweighted on a 6:1 imbalance would degenerate to a majority-class-biased
+  classifier without this being a form of tuning against the test set; `balanced` is a
+  standard, data-blind rebalancing scheme (inverse of class frequency), not a
+  hyperparameter searched against results.
+- No cross-validation / grid search — a single fit on the full training split, as specified
+  by "default sklearn RF" in the task brief.
+
+## Metrics (reported for both models on the test set)
+
+Accuracy, precision, recall, F1 (all for the `first_crack` positive class, matching the
+convention `evaluate.py` / `evaluate_onnx.py` already use in this repo), ROC-AUC, and
+per-window inference latency (feature extraction + predict, end-to-end, matching how
+`evaluate_onnx.py` times ONNX latency).
+
+## Comparator
+
+AST INT8 (`exports/onnx/int8`), using the already-measured 12 Jul numbers from the #55
+reconciliation (`results/baseline_v5_303set/onnx_int8_eval.json`) — not re-run, since
+nothing about the AST model changes here; re-quoting the existing measurement avoids a
+redundant multi-minute ONNX pass.
+
+## What counts as "favourable to RF"
+
+Any metric where RF's test-set number is equal to or higher than AST-int8's. Reported
+honestly regardless of outcome — this document is written before the comparison is run, so
+there is no result yet to be favourable or unfavourable to.

--- a/results/rf_mfcc_baseline/RESULTS.json
+++ b/results/rf_mfcc_baseline/RESULTS.json
@@ -1,0 +1,28 @@
+{
+  "model": "RandomForestClassifier+MFCC",
+  "seed": 42,
+  "class_weight": "balanced",
+  "n_train_samples": 922,
+  "n_test_samples": 303,
+  "n_mfcc": 20,
+  "accuracy": 0.868,
+  "precision": 0.5294,
+  "recall": 0.4286,
+  "f1": 0.4737,
+  "roc_auc": 0.9036,
+  "confusion_matrix": [
+    [
+      245,
+      16
+    ],
+    [
+      24,
+      18
+    ]
+  ],
+  "latency": {
+    "p50_ms": 7.562415907159448,
+    "p95_ms": 7.976637501269579,
+    "mean_ms": 7.6331532915298
+  }
+}

--- a/results/rf_mfcc_baseline/RESULTS.md
+++ b/results/rf_mfcc_baseline/RESULTS.md
@@ -1,0 +1,95 @@
+# RF + MFCC comparator — results (12 Jul)
+
+Protocol pre-registered in `PROTOCOL.md` in this directory, written and committed before this
+script was run against the test set. Nothing in the protocol was changed after seeing these
+numbers.
+
+## Head-to-head vs AST INT8
+
+| Metric | RF + MFCC | AST INT8 (ONNX) | Favours |
+|---|---|---|---|
+| Accuracy | 86.80% | 98.35% | AST |
+| Precision (`first_crack`) | 52.94% | 91.11% | AST |
+| Recall (`first_crack`) | 42.86% | 97.62% | AST |
+| F1 | 0.474 | 0.943 | AST |
+| ROC-AUC | 0.904 | 0.998 | AST |
+| Confusion (TN/FP/FN/TP) | 245/16/24/18 | 257/4/1/41 | AST |
+| Inference latency (per 10s window, this Mac) | ~7.6ms p50 | ~216ms p50 | **RF** |
+
+AST is favoured on every quality metric; RF wins only on latency, by roughly 28×.
+
+**AST INT8 numbers** are quoted from the 12 Jul #55 reconciliation
+(`results/baseline_v5_303set/onnx_int8_eval.json`, quality; `latency_benchmark_mac.json` /
+`scripts/benchmark_platforms.py`, latency) rather than re-run here — nothing about the AST
+model changes in this comparison, so re-running would be redundant.
+
+**Latency methodology note**: the two latency figures share the same measurement *boundary*
+(isolated feature-extraction + model-inference call, no file I/O — neither includes the
+`librosa.load()` disk read) but not the same *sampling scheme*, so "~7.6ms vs ~216ms" is not
+an apples-to-apples repeat-count comparison:
+- AST INT8 (216ms p50): `benchmark_platforms.py`'s controlled benchmark — **one fixed
+  synthetic 10s window, timed 30 times** after 5 warmup runs, p50 taken across those 30
+  repeats of the same input.
+- RF+MFCC (~7.6ms p50): this script — **303 distinct real test-set windows, each timed
+  once**, p50 taken across those 303 different inputs (no repeat timing of a single window,
+  no separate warmup).
+Both are legitimate "warm, isolated inference call" measurements (as opposed to the slower
+end-to-end `evaluate_onnx.py` eval-loop timing, which also includes file I/O and runs ~637ms
+p50 for the same INT8 model on this machine) — but the RF figure additionally reflects
+real across-sample variance (different audio content, different feature-extraction cost per
+clip) that the AST figure's fixed-input repeat sampling does not. The ~28× gap is real and
+not an artifact of this difference (RF's `p95` of 7.72ms in the bare-default run is still
+~28× below AST's own warmup-adjusted range), but the two numbers were not produced by
+identical harnesses.
+
+## Honest read
+
+RF on plain-vanilla MFCC summary statistics is not competitive with the fine-tuned AST model
+on this dataset — recall in particular collapses to 42.9% (24 missed first-cracks out of 42),
+which is disqualifying for this application (a missed FC over-roasts until an operator
+override — see AGENTS.md's stated precision/recall priority). The 28× latency advantage does
+not offset a >2x drop in recall.
+
+This is consistent with the task's expectation that RF+MFCC is a comparator baseline, not a
+contender: Shi et al. 2026 report ~95.7% accuracy / 0.992 AUC for RF+MFCC on their own
+(different) dataset — this repo's 21-recording, two-microphone, real-roast dataset with
+mic-gain variation across recordings (see README Limitations) is evidently harder for a
+fixed, non-learned feature representation than whatever produced their result; the AST
+model's advantage here plausibly comes from the pretrained AudioSet representation (72M
+frozen params) plus fine-tuning, which a 40-dimensional MFCC summary can't match. No claim is
+made about why Shi et al.'s number was higher — different data, different preprocessing,
+different label definition are all plausible and unverified from here.
+
+**Not favourable to RF on any accuracy-family metric.** Reporting this as such per the task
+brief's explicit instruction to call out honestly if the comparison favours RF on any metric —
+it does not, except latency.
+
+**Transparency check on `class_weight="balanced"`**: since this is the one non-bare-default
+choice in the protocol, it was checked against a truly bare `RandomForestClassifier
+(random_state=42)` (no `class_weight`, i.e. `--class-weight none`) to confirm it wasn't
+inadvertently cherry-picked toward a flattering number. This check is reproducible from the
+committed CLI, not a one-off interactive run — see `--class-weight` below. Bare-default
+result (`results/rf_mfcc_baseline/RESULTS_bare_default.json`): 85.8% accuracy, 48.8%
+precision, 50.0% recall, F1 0.494, ROC-AUC 0.879, confusion 239/22/21/21. That's *higher* F1
+than the balanced run (0.494 vs 0.474) and lower ROC-AUC/accuracy — a wash, not an
+improvement, confirming `class_weight="balanced"` was not selected because it flattered RF.
+Both configurations land far short of AST on every quality metric; the headline RF numbers in
+the table above are the protocol-specified `class_weight="balanced"` run.
+
+## Reproduce
+
+```bash
+# Protocol default (class_weight="balanced")
+python scripts/rf_mfcc_baseline.py \
+  --train-dir data/splits/train --test-dir data/splits/test \
+  --output results/rf_mfcc_baseline/RESULTS.json
+
+# Transparency check (bare sklearn default, no class_weight)
+python scripts/rf_mfcc_baseline.py \
+  --train-dir data/splits/train --test-dir data/splits/test \
+  --class-weight none \
+  --output results/rf_mfcc_baseline/RESULTS_bare_default.json
+```
+
+Raw JSON: `results/rf_mfcc_baseline/RESULTS.json` (protocol default),
+`results/rf_mfcc_baseline/RESULTS_bare_default.json` (transparency check).

--- a/results/rf_mfcc_baseline/RESULTS_bare_default.json
+++ b/results/rf_mfcc_baseline/RESULTS_bare_default.json
@@ -1,0 +1,28 @@
+{
+  "model": "RandomForestClassifier+MFCC",
+  "seed": 42,
+  "class_weight": "none",
+  "n_train_samples": 922,
+  "n_test_samples": 303,
+  "n_mfcc": 20,
+  "accuracy": 0.8581,
+  "precision": 0.4884,
+  "recall": 0.5,
+  "f1": 0.4941,
+  "roc_auc": 0.8791,
+  "confusion_matrix": [
+    [
+      239,
+      22
+    ],
+    [
+      21,
+      21
+    ]
+  ],
+  "latency": {
+    "p50_ms": 7.476042024791241,
+    "p95_ms": 7.722224318422377,
+    "mean_ms": 7.51174344272405
+  }
+}

--- a/scripts/rf_mfcc_baseline.py
+++ b/scripts/rf_mfcc_baseline.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Random Forest + MFCC comparator baseline for first-crack detection.
+
+A classical, non-transformer comparator for the AST-based detector, following the
+pre-registered protocol in ``results/rf_mfcc_baseline/PROTOCOL.md``. Trains a
+``RandomForestClassifier`` on standard MFCC summary statistics (librosa, not the
+Kaldi-compatible :class:`~coffee_first_crack.mel_frontend.MelFrontend` the AST
+torch-free path needs) using ``data/splits/train/``, and evaluates on
+``data/splits/test/`` — the same 303-sample set every other comparator in this repo
+uses. Never touches the test set until final evaluation.
+
+Usage::
+
+    python scripts/rf_mfcc_baseline.py \\
+        --train-dir data/splits/train \\
+        --test-dir data/splits/test \\
+        --output results/rf_mfcc_baseline/RESULTS.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+
+import librosa
+import numpy as np
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.metrics import (
+    accuracy_score,
+    classification_report,
+    confusion_matrix,
+    f1_score,
+    precision_score,
+    recall_score,
+    roc_auc_score,
+)
+
+# Canonical label mapping — must stay in sync with configs/default.yaml
+LABEL2ID: dict[str, int] = {"no_first_crack": 0, "first_crack": 1}
+
+SAMPLE_RATE = 16000
+N_MFCC = 20
+
+
+def _collect_samples(split_dir: Path) -> list[tuple[Path, int]]:
+    """Walk a split directory and return ``(wav_path, label_id)`` pairs.
+
+    Args:
+        split_dir: Directory with ``first_crack/`` and ``no_first_crack/`` subdirs.
+
+    Returns:
+        List of ``(wav_path, label_id)`` tuples, sorted for determinism.
+    """
+    samples: list[tuple[Path, int]] = []
+    for label_name, label_id in LABEL2ID.items():
+        label_dir = split_dir / label_name
+        if not label_dir.exists():
+            print(f"Warning: {label_dir} not found, skipping")
+            continue
+        for wav_path in sorted(label_dir.glob("*.wav")):
+            samples.append((wav_path, label_id))
+    print(f"Collected {len(samples)} samples from {split_dir}")
+    for label_name, label_id in LABEL2ID.items():
+        count = sum(1 for _, lid in samples if lid == label_id)
+        print(f"  {label_name}: {count}")
+    return samples
+
+
+def extract_mfcc_features(audio: np.ndarray) -> np.ndarray:
+    """Extract a fixed-length MFCC summary feature vector for one audio clip.
+
+    Per the pre-registered protocol: mean + standard deviation of ``N_MFCC``
+    MFCC coefficients across time frames, using librosa's standard (non-Kaldi)
+    implementation — this is a comparator baseline, not a numerical-equivalence
+    target, so it does not need the AST frontend's Kaldi-fbank compatibility.
+
+    Args:
+        audio: 1-D mono waveform sampled at :data:`SAMPLE_RATE`.
+
+    Returns:
+        A ``(2 * N_MFCC,)`` feature vector: ``N_MFCC`` means followed by
+        ``N_MFCC`` standard deviations.
+    """
+    mfcc = librosa.feature.mfcc(y=audio, sr=SAMPLE_RATE, n_mfcc=N_MFCC)
+    return np.concatenate([mfcc.mean(axis=1), mfcc.std(axis=1)])
+
+
+def _load_features(samples: list[tuple[Path, int]]) -> tuple[np.ndarray, np.ndarray]:
+    """Load audio and extract MFCC features for a list of samples.
+
+    Args:
+        samples: ``(wav_path, label_id)`` pairs.
+
+    Returns:
+        Tuple of ``(X, y)`` — feature matrix and integer label array.
+    """
+    features: list[np.ndarray] = []
+    labels: list[int] = []
+    for wav_path, label_id in samples:
+        audio, _ = librosa.load(str(wav_path), sr=SAMPLE_RATE, mono=True)
+        features.append(extract_mfcc_features(audio))
+        labels.append(label_id)
+    return np.stack(features), np.array(labels)
+
+
+def run(
+    train_dir: Path,
+    test_dir: Path,
+    output_path: Path | None = None,
+    seed: int = 42,
+    class_weight: str = "balanced",
+) -> dict[str, object]:
+    """Train the RF+MFCC comparator and evaluate on the test split.
+
+    Args:
+        train_dir: Training split directory (``data/splits/train``).
+        test_dir: Test split directory (``data/splits/test``) — used only for
+            final evaluation, never for feature selection or tuning.
+        output_path: Optional path to write JSON results.
+        seed: Random seed, matching the repo's ``configs/default.yaml`` convention.
+        class_weight: ``"balanced"`` (protocol default — data-blind inverse-frequency
+            rebalancing for the ~15% positive training split, 136:786) or ``"none"``
+            (bare ``RandomForestClassifier`` default, no rebalancing). Exposed as a CLI
+            flag so the PROTOCOL.md transparency check comparing the two is itself
+            reproducible from the committed script, not just a one-off interactive run.
+
+    Returns:
+        Dict with metrics, confusion matrix, and per-window inference latency.
+    """
+    print(f"\n=== Training data: {train_dir} ===")
+    train_samples = _collect_samples(train_dir)
+    if not train_samples:
+        raise ValueError(f"No training samples found in {train_dir}")
+
+    print("\nExtracting MFCC features (train)...")
+    train_features, train_labels = _load_features(train_samples)
+
+    # class_weight="balanced" is the PROTOCOL.md default — data-blind inverse-frequency
+    # rebalancing for the ~15% positive training split, not a hyperparameter search.
+    # class_weight="none" reproduces the bare-default transparency check. All other
+    # RandomForestClassifier args are sklearn defaults either way.
+    sklearn_class_weight = None if class_weight == "none" else class_weight
+    clf = RandomForestClassifier(random_state=seed, class_weight=sklearn_class_weight)
+    print(f"\nFitting RandomForestClassifier (seed={seed}, class_weight={class_weight})...")
+    clf.fit(train_features, train_labels)
+
+    print(f"\n=== Test data: {test_dir} ===")
+    test_samples = _collect_samples(test_dir)
+    if not test_samples:
+        raise ValueError(f"No test samples found in {test_dir}")
+
+    print("\nExtracting MFCC features + predicting (test, timed end-to-end)...")
+    y_true: list[int] = []
+    y_pred: list[int] = []
+    y_prob: list[float] = []
+    latencies_ms: list[float] = []
+
+    for i, (wav_path, label_id) in enumerate(test_samples):
+        audio, _ = librosa.load(str(wav_path), sr=SAMPLE_RATE, mono=True)
+
+        t0 = time.perf_counter()
+        feats = extract_mfcc_features(audio).reshape(1, -1)
+        pred_id = int(clf.predict(feats)[0])
+        prob_fc = float(clf.predict_proba(feats)[0, 1])
+        elapsed_ms = (time.perf_counter() - t0) * 1000
+
+        y_true.append(label_id)
+        y_pred.append(pred_id)
+        y_prob.append(prob_fc)
+        latencies_ms.append(elapsed_ms)
+
+        if (i + 1) % 50 == 0 or (i + 1) == len(test_samples):
+            print(f"  [{i + 1}/{len(test_samples)}]")
+
+    acc = accuracy_score(y_true, y_pred)
+    precision = precision_score(y_true, y_pred, pos_label=1, zero_division=0)
+    recall = recall_score(y_true, y_pred, pos_label=1, zero_division=0)
+    f1 = f1_score(y_true, y_pred, pos_label=1, zero_division=0)
+    roc_auc = roc_auc_score(y_true, y_prob)
+    cm = confusion_matrix(y_true, y_pred).tolist()
+
+    latency_arr = np.array(latencies_ms)
+    latency_stats = {
+        "p50_ms": float(np.percentile(latency_arr, 50)),
+        "p95_ms": float(np.percentile(latency_arr, 95)),
+        "mean_ms": float(np.mean(latency_arr)),
+    }
+
+    print("\n" + "=" * 60)
+    print("RF + MFCC — TEST SET RESULTS")
+    print("=" * 60)
+    print(f"  Accuracy:  {acc:.4f}")
+    print(f"  Precision: {precision:.4f}")
+    print(f"  Recall:    {recall:.4f}")
+    print(f"  F1:        {f1:.4f}")
+    print(f"  ROC-AUC:   {roc_auc:.4f}")
+    print(f"  Confusion matrix: {cm}")
+    print(
+        f"  Latency: p50={latency_stats['p50_ms']:.2f}ms "
+        f"p95={latency_stats['p95_ms']:.2f}ms mean={latency_stats['mean_ms']:.2f}ms"
+    )
+    print("\nClassification Report:")
+    print(classification_report(y_true, y_pred, target_names=list(LABEL2ID.keys())))
+
+    results: dict[str, object] = {
+        "model": "RandomForestClassifier+MFCC",
+        "seed": seed,
+        "class_weight": class_weight,
+        "n_train_samples": len(train_samples),
+        "n_test_samples": len(test_samples),
+        "n_mfcc": N_MFCC,
+        "accuracy": round(float(acc), 4),
+        "precision": round(float(precision), 4),
+        "recall": round(float(recall), 4),
+        "f1": round(float(f1), 4),
+        "roc_auc": round(float(roc_auc), 4),
+        "confusion_matrix": cm,
+        "latency": latency_stats,
+    }
+
+    if output_path:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with output_path.open("w") as f:
+            json.dump(results, f, indent=2)
+        print(f"\nResults saved to {output_path}")
+
+    return results
+
+
+def main() -> None:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="Random Forest + MFCC comparator baseline for first-crack detection"
+    )
+    parser.add_argument(
+        "--train-dir",
+        type=Path,
+        default=Path("data/splits/train"),
+        help="Training split directory (default: data/splits/train)",
+    )
+    parser.add_argument(
+        "--test-dir",
+        type=Path,
+        default=Path("data/splits/test"),
+        help="Test split directory (default: data/splits/test)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Path to write JSON results (optional)",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Random seed (default: 42, matches configs/default.yaml)",
+    )
+    parser.add_argument(
+        "--class-weight",
+        type=str,
+        choices=["balanced", "none"],
+        default="balanced",
+        help=(
+            "RandomForestClassifier class_weight: 'balanced' (default, protocol-specified "
+            "inverse-frequency rebalancing) or 'none' (bare sklearn default, reproduces the "
+            "PROTOCOL.md transparency check)"
+        ),
+    )
+    args = parser.parse_args()
+
+    if not args.train_dir.exists():
+        print(f"Error: training directory not found: {args.train_dir}")
+        raise SystemExit(1)
+    if not args.test_dir.exists():
+        print(f"Error: test directory not found: {args.test_dir}")
+        raise SystemExit(1)
+
+    run(
+        train_dir=args.train_dir,
+        test_dir=args.test_dir,
+        output_path=args.output,
+        seed=args.seed,
+        class_weight=args.class_weight,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_rf_mfcc_baseline.py
+++ b/tests/test_rf_mfcc_baseline.py
@@ -1,0 +1,146 @@
+"""Tests for scripts/rf_mfcc_baseline.py.
+
+Hardware/data-free — uses synthetic audio, never touches ``data/splits/``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import soundfile as sf
+from sklearn.ensemble import RandomForestClassifier
+
+import scripts.rf_mfcc_baseline as rf_baseline
+
+
+def _write_wav(path: Path, duration_sec: float = 1.0, sample_rate: int = 16000) -> None:
+    """Write a tiny synthetic WAV file at the given path (silence, fast to load)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    samples = np.zeros(int(duration_sec * sample_rate), dtype=np.float32)
+    sf.write(str(path), samples, sample_rate)
+
+
+def test_extract_mfcc_features_shape() -> None:
+    """The feature vector is 2 * N_MFCC (mean + std per coefficient)."""
+    rng = np.random.default_rng(seed=0)
+    audio = rng.standard_normal(rf_baseline.SAMPLE_RATE * 10).astype(np.float32)
+
+    features = rf_baseline.extract_mfcc_features(audio)
+
+    assert features.shape == (2 * rf_baseline.N_MFCC,)
+    assert np.all(np.isfinite(features))
+
+
+def test_extract_mfcc_features_deterministic() -> None:
+    """The same audio always yields the same feature vector (no hidden RNG)."""
+    rng = np.random.default_rng(seed=1)
+    audio = rng.standard_normal(rf_baseline.SAMPLE_RATE * 10).astype(np.float32)
+
+    first = rf_baseline.extract_mfcc_features(audio)
+    second = rf_baseline.extract_mfcc_features(audio.copy())
+
+    np.testing.assert_array_equal(first, second)
+
+
+def test_extract_mfcc_features_distinguishes_silence_from_noise() -> None:
+    """Silence and noise should not collapse to an identical feature vector."""
+    silence = np.zeros(rf_baseline.SAMPLE_RATE * 10, dtype=np.float32)
+    rng = np.random.default_rng(seed=2)
+    noise = rng.standard_normal(rf_baseline.SAMPLE_RATE * 10).astype(np.float32)
+
+    silence_features = rf_baseline.extract_mfcc_features(silence)
+    noise_features = rf_baseline.extract_mfcc_features(noise)
+
+    assert not np.allclose(silence_features, noise_features)
+
+
+def test_collect_samples_reads_label_directories(tmp_path: Path) -> None:
+    """`_collect_samples` walks first_crack/no_first_crack subdirs and labels them."""
+    fc_dir = tmp_path / "first_crack"
+    nfc_dir = tmp_path / "no_first_crack"
+    fc_dir.mkdir()
+    nfc_dir.mkdir()
+    (fc_dir / "a.wav").touch()
+    (nfc_dir / "b.wav").touch()
+    (nfc_dir / "c.wav").touch()
+
+    samples = rf_baseline._collect_samples(tmp_path)
+
+    labels = sorted(label for _, label in samples)
+    assert labels == [0, 0, 1]
+    assert len(samples) == 3
+
+
+def test_collect_samples_missing_label_dir_warns(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A missing label subdirectory is skipped with a warning, not a crash."""
+    (tmp_path / "first_crack").mkdir()
+
+    samples = rf_baseline._collect_samples(tmp_path)
+
+    assert samples == []
+    assert "no_first_crack" in capsys.readouterr().out
+
+
+def test_run_raises_on_empty_train_dir(tmp_path: Path) -> None:
+    """`run()` fails fast if the training split has no samples."""
+    train_dir = tmp_path / "train"
+    test_dir = tmp_path / "test"
+    (train_dir / "first_crack").mkdir(parents=True)
+    (train_dir / "no_first_crack").mkdir(parents=True)
+    (test_dir / "first_crack").mkdir(parents=True)
+    (test_dir / "no_first_crack").mkdir(parents=True)
+
+    with pytest.raises(ValueError, match="No training samples"):
+        rf_baseline.run(train_dir=train_dir, test_dir=test_dir)
+
+
+def test_run_fits_before_reading_test_samples(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`run()` must fully fit the classifier on train data before it ever reads the
+    test directory — a leakage-regression guard for the "train, then evaluate,
+    never the other way round" protocol invariant.
+
+    Wraps ``RandomForestClassifier.fit`` and the module's ``_collect_samples`` to
+    record call order into a shared event log, using real (silent) WAV fixtures
+    for both splits so the wrapped calls exercise the actual code path, not a
+    stub. Asserts ``fit`` is logged before the test directory's ``_collect_samples``
+    call — i.e. training is complete before test data is even enumerated, let
+    alone loaded or scored.
+    """
+    train_dir = tmp_path / "train"
+    test_dir = tmp_path / "test"
+    for split_dir, count in ((train_dir, 4), (test_dir, 2)):
+        for label in ("first_crack", "no_first_crack"):
+            for i in range(count):
+                _write_wav(split_dir / label / f"chunk_{i:03d}.wav")
+
+    events: list[str] = []
+
+    real_fit = RandomForestClassifier.fit
+
+    def _tracked_fit(self: RandomForestClassifier, *args: object, **kwargs: object) -> object:
+        events.append("fit")
+        return real_fit(self, *args, **kwargs)
+
+    real_collect_samples = rf_baseline._collect_samples
+
+    def _tracked_collect_samples(split_dir: Path) -> list[tuple[Path, int]]:
+        events.append(f"collect_samples:{split_dir.name}")
+        return real_collect_samples(split_dir)
+
+    monkeypatch.setattr(RandomForestClassifier, "fit", _tracked_fit)
+    monkeypatch.setattr(rf_baseline, "_collect_samples", _tracked_collect_samples)
+
+    rf_baseline.run(train_dir=train_dir, test_dir=test_dir)
+
+    assert "fit" in events, "fit() was never called"
+    fit_index = events.index("fit")
+    test_collect_index = events.index(f"collect_samples:{test_dir.name}")
+    assert fit_index < test_collect_index, (
+        f"classifier must be fit before the test directory is read; got order {events}"
+    )


### PR DESCRIPTION
## Summary

A classical, non-transformer comparator against the AST-based detector, per the Shi et al. 2026 reference point (Applied Food Research 6(1):102058 — RF on MFCC features, ~95.7% accuracy / 0.992 AUC on their own, different data). Protocol pre-registered in `results/rf_mfcc_baseline/PROTOCOL.md` (splits, features, hyperparameter policy) before the script was run against the test set — verified via file mtimes, not just asserted.

**RF+MFCC is not competitive with AST INT8 on this dataset — this is the honest headline:**

| Metric | RF + MFCC | AST INT8 (ONNX) | Favours |
|---|---|---|---|
| Accuracy | 86.80% | 98.35% | AST |
| Precision (`first_crack`) | 52.94% | 91.11% | AST |
| Recall (`first_crack`) | 42.86% | 97.62% | AST |
| F1 | 0.474 | 0.943 | AST |
| ROC-AUC | 0.904 | 0.998 | AST |
| Confusion (TN/FP/FN/TP) | 245/16/24/18 | 257/4/1/41 | AST |
| Inference latency (this Mac) | ~7.6ms p50 | ~216ms p50 | **RF** |

**Recall collapsing to 42.9% (24 of 42 first-cracks missed) is disqualifying for this application** — a missed FC over-roasts until an operator override. RF wins only on latency (~28x), and even that comparison is documented with its methodology caveat rather than oversold (see below). AST INT8 numbers are quoted from the 12 Jul #55 reconciliation (#64) rather than re-run — nothing about AST changes here.

Reported honestly per the task brief's instruction to call out any metric that favours RF — none of the quality metrics do.

## Changes

- `scripts/rf_mfcc_baseline.py` — training/eval CLI (standard librosa MFCCs, `n_mfcc=20`, mean+std summary → 40-dim feature vector; `RandomForestClassifier` with sklearn defaults except `random_state=42` and `class_weight="balanced"`, both justified as data-blind, not tuned against test results)
- `tests/test_rf_mfcc_baseline.py` — 7 hardware/data-free unit tests: feature shape/determinism/discriminability, sample collection, empty-dir failure, and a leakage-regression test asserting the classifier is fully fit before the test directory is ever read (monkeypatched call-order assertion against real synthetic WAV fixtures, not a stub)
- `results/rf_mfcc_baseline/PROTOCOL.md` — pre-registered protocol
- `results/rf_mfcc_baseline/RESULTS.md` — head-to-head writeup + honest read + transparency check
- `results/rf_mfcc_baseline/RESULTS.json` — protocol-default (`class_weight="balanced"`) raw metrics
- `results/rf_mfcc_baseline/RESULTS_bare_default.json` — transparency-check raw metrics (bare sklearn default, no class_weight)

No new dependency — scikit-learn and librosa are already core deps in `pyproject.toml`.

**Pre-open review: 1 medium + 2 lows found and folded:**
1. MEDIUM — the bare-default transparency run wasn't reproducible from committed code (hardcoded `class_weight="balanced"`, no backing JSON). Added `--class-weight {balanced,none}` to the CLI, re-ran the bare configuration through it, committed `RESULTS_bare_default.json`. Re-verified both configs reproduce identically to the original interactive numbers.
2. LOW — "the same methodology" for the latency comparison overstated it. Rewrote to name the actual difference: same measurement boundary (no I/O, feature-extraction + inference only) but different sampling schemes (AST: p50 of 30 repeats on one synthetic window; RF: p50 across 303 distinct real samples, each timed once).
3. LOW — added the `run()`-level leakage-regression test described above.

## Test plan
- [x] `ruff check .` clean
- [x] `ruff format --check .` clean
- [x] `pyright src/` clean (scripts/ is out of pyright's configured scope, matching `evaluate_onnx.py` precedent)
- [x] `pytest` — 184 passed (183 prior + 1 new leakage test), no regressions
- [x] Both RF configs (`balanced` and `none`) re-run through the final CLI and confirmed to reproduce their originally-reported numbers exactly
- [x] Confirmed nothing under `experiments/` or `data/` is staged; no audio/weights committed

Co-Authored-By: Oz <oz-agent@warp.dev>