### PR TITLE
docs: record main branch protection in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,6 +229,11 @@ After completing a story:
 3. Comment on the GitHub story issue with a delivery summary, then close it
 4. Tick the checkbox in GitHub epic issue #1
 5. Open a PR referencing the story issue
+6. **Merging (12 Jul 2026): `main` is branch-protected** — the three CI jobs
+   (Test, Lint, Torch-free import gate) are required status checks (strict:
+   branch must be up to date), conversation resolution is required, and
+   `enforce_admins` is on. `gh pr merge --auto --squash` is safe again: it
+   waits for the checks. Never merge on red or with unresolved threads.
 
 ---
 


### PR DESCRIPTION
Documents the branch protection applied 12 Jul (operator-approved): Test/Lint/Torch-free required (strict), conversation resolution, enforce_admins, no force-push/deletion. This PR doubles as the end-to-end smoke test that --auto now waits for green.