### PR TITLE
docs: data workflow matches the MCP-recorder reality + retraining checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ detector.start()
 ### ONNX (Raspberry Pi 5) — torch-free
 
 ONNX models are published on HuggingFace Hub under `onnx/fp32/` and `onnx/int8/`:
-- **INT8 (recommended)**: `onnx/int8/model_quantized.onnx` — 90MB, 2x faster, no measurable quality loss (earlier-checkpoint validation, not re-benchmarked on baseline_v5)
+- **INT8 (recommended)**: `onnx/int8/model_quantized.onnx` — 90MB, 2x faster, no measurable quality loss. Re-benchmarked on baseline_v5's 303-sample test set (12 Jul 2026): 91.1% precision / 97.6% recall / F1 0.943 on `first_crack`, marginally ahead of fp32 and with no quality loss (see [Evaluation](#evaluation)). Reproduce with `python scripts/evaluate_onnx.py --onnx-dir exports/onnx/int8 --test-dir data/splits/test`.
 - **FP32**: `onnx/fp32/model.onnx` — 345MB
 
 Pi/ONNX inference uses `coffee_first_crack.inference_onnx.OnnxSlidingWindowInference`, which
@@ -247,6 +247,60 @@ Full dataset: 1,435 × 10s chunks (fixed sliding window), 922 / 210 / 303 train 
 | mic2-brazil-roast3-amplified | mic-2 | 10:39 | 10:33 | **-6s** |
 | mic2-panama-roast1 | mic-2 | 11:05 | 10:57 | **-8s** |
 | roast-3-costarica-hermosa-hp-a | mic-1 | 07:19 | MISSED | — |
+
+---
+
+## Retraining & updating metrics
+
+When new recordings are added to the dataset, rebuild the splits (see
+[docs/data_preparation.md](docs/data_preparation.md)), then retrain, evaluate,
+export, and re-benchmark the ONNX export:
+
+```bash
+# 1. Train (reads data/splits, writes a checkpoint under experiments/)
+python -m coffee_first_crack.train --data-dir data/splits --experiment-name baseline_vN
+
+# 2. Evaluate the PyTorch/AST checkpoint on the test split
+python -m coffee_first_crack.evaluate \
+  --model-dir experiments/baseline_vN/checkpoint-best \
+  --test-dir data/splits/test \
+  --output-dir experiments/baseline_vN/evaluation
+
+# 3. Export to ONNX (INT8 quantized by default; --no-quantize to skip)
+python -m coffee_first_crack.export_onnx \
+  --model-dir experiments/baseline_vN/checkpoint-best \
+  --output-dir exports/onnx --quantize
+
+# 4. Re-benchmark the ONNX INT8 export on the SAME test split
+python scripts/evaluate_onnx.py \
+  --onnx-dir exports/onnx/int8 \
+  --test-dir data/splits/test \
+  --output results/baseline_vN_int8_eval.json
+```
+
+The `train-first-crack`, `evaluate-first-crack`, and `export-onnx-first-crack`
+console scripts (declared in `pyproject.toml`) are equivalent to the module
+invocations above.
+
+**After a retrain, update these docs so the numbers match reality:**
+
+- the **Evaluation** table in this README (both fp32 and INT8 columns) and the
+  INT8 note in the [ONNX](#onnx-raspberry-pi-5--torch-free) section;
+- `data/DATASET_CARD.md` (split counts, source-recordings table, and the
+  "Last updated" line) whenever the dataset itself changed.
+
+**What is committed vs published vs ignored:**
+
+- **Committed to git:** the evaluation artifacts under
+  `experiments/<name>/evaluation/` (`test_results.txt` / `.json`,
+  `confusion_matrix.png`) and any `results/*.json` you keep as provenance, plus
+  the doc updates above. Note `data/raw/`, `data/processed/`, `data/splits/`,
+  `experiments/`, `exports/`, and `*.onnx` are **gitignored** (large binaries) —
+  only the small text/JSON eval outputs you explicitly `git add -f` are tracked.
+- **Pushed to HuggingFace Hub:** the model weights and ONNX exports —
+  `python -m coffee_first_crack.train ... --push-to-hub`, or `scripts/push_to_hub.py`.
+- **Left gitignored (local only):** everything under `experiments/` and
+  `exports/` except the small eval artifacts you force-add.
 
 ---
 

--- a/data/DATASET_CARD.md
+++ b/data/DATASET_CARD.md
@@ -15,11 +15,11 @@ dataset_info:
     dtype: string
   splits:
   - name: train
-    num_examples: 587
+    num_examples: 922
   - name: val
-    num_examples: 195
+    num_examples: 210
   - name: test
-    num_examples: 191
+    num_examples: 303
 task_categories:
   - audio-classification
 language:
@@ -49,18 +49,20 @@ Audio dataset for training coffee first crack detection models. Contains 10-seco
 > **Original prototype:**
 > - Part 1 — [Training a Neural Network to Detect Coffee First Crack from Audio](https://dev.to/syamaner/part-1-training-a-neural-network-to-detect-coffee-first-crack-from-audio-an-agentic-development-1jei)
 
+> **Last updated:** 12 Jul 2026 (baseline_v5, 303-sample test set).
+
 ## Dataset Summary
 
-- **973 total chunks** (fixed 10-second sliding windows, no overlap)
-- **15 source recordings** from 2 microphones, 3 coffee origins
+- **1,435 total chunks** (fixed 10-second sliding windows, no overlap)
+- **21 source recordings** from 4 microphone configurations, 4 coffee origins
 - **Recording-level split** (no data leakage between splits)
-- **20% first_crack / 80% no_first_crack** — realistic class imbalance
+- **~16% first_crack / ~84% no_first_crack** — realistic class imbalance
 
 | Split | first_crack | no_first_crack | Total | Recordings |
 |-------|-------------|----------------|-------|------------|
-| Train | 124 | 463 | 587 | 9 |
-| Val | 37 | 158 | 195 | 3 |
-| Test | 36 | 155 | 191 | 3 |
+| Train | 136 | 786 | 922 | 14 |
+| Val | 45 | 165 | 210 | 3 |
+| Test | 42 | 261 | 303 | 4 |
 
 ## Annotation Approach
 
@@ -75,17 +77,23 @@ This approach replaces the prototype method of manually annotating 20-30 small r
 | `audio` | Audio (16kHz) | 10-second mono WAV chunk |
 | `label` | string | `first_crack` or `no_first_crack` |
 | `label_id` | int | 1 = first_crack, 0 = no_first_crack |
-| `microphone` | string | `mic-1-original` or `mic-2-new` |
-| `coffee_origin` | string | e.g. `brazil`, `costarica-hermosa`, `brazil-santos` |
+| `microphone` | string | e.g. `mic-1-original`, `mic-2-new`, `mic-1-new`, `mic-2-new` |
+| `coffee_origin` | string | e.g. `brazil`, `costarica-hermosa`, `brazil-santos`, `panama-hortigal-estate` |
 
 ## Source Recordings
 
+Current baseline (**baseline_v5**, 21 recordings): 9 legacy mic-1 + 6 amplified
+mic-2 + 3 mic-1-panama + 3 mic-2-panama. Reconciled against
+`data/splits/split_report.md` on 12 Jul 2026.
+
 | Mic | Origin | Recordings | Notes |
 |-----|--------|------------|-------|
-| mic-1-original | costarica-hermosa | 5 | Legacy recordings from prototype |
-| mic-1-original | brazil | 4 | Legacy recordings from prototype |
-| mic-2-new | brazil | 4 | New recordings (Feb 2026) |
-| mic-2-new | brazil-santos | 2 | New recordings (Apr 2026) |
+| mic-1-original | costarica-hermosa | 5 | Legacy recordings from prototype (4 `hp-a` + 1 `.alog`) |
+| mic-1-original | brazil | 4 | Legacy recordings from prototype (`.alog`) |
+| mic-2-new | brazil | 4 | Single-mic recordings (Feb 2026), gain-amplified |
+| mic-2-new | brazil-santos | 2 | Single-mic recordings (Apr 2026), gain-amplified |
+| mic-1-new (FIFINE) | panama-hortigal-estate | 3 | Multi-mic paired recordings |
+| mic-2-new (ATR2100x) | panama-hortigal-estate | 3 | Multi-mic paired recordings |
 
 ## Usage
 
@@ -95,9 +103,9 @@ from datasets import load_dataset
 ds = load_dataset("syamaner/coffee-first-crack-audio")
 print(ds)
 # DatasetDict({
-#     train: Dataset({features: [audio, label, ...], num_rows: 587})
-#     val: Dataset({features: [audio, label, ...], num_rows: 195})
-#     test: Dataset({features: [audio, label, ...], num_rows: 191})
+#     train: Dataset({features: [audio, label, ...], num_rows: 922})
+#     val: Dataset({features: [audio, label, ...], num_rows: 210})
+#     test: Dataset({features: [audio, label, ...], num_rows: 303})
 # })
 
 # Access a sample

--- a/docs/data_preparation.md
+++ b/docs/data_preparation.md
@@ -1,24 +1,116 @@
 # Data Preparation Guide
 
-Full pipeline from raw Audacity recording to training-ready splits.
+Full pipeline from raw recording to training-ready splits.
 
 ---
 
 ## Overview
 
 ```
-Audacity (.aup3)
-    → Export WAV
-        → Label Studio (annotate first_crack regions)
-            → convert_labelstudio_export.py  (JSON annotations)
-                → chunk_audio.py             (10s WAV chunks)
-                    → dataset_splitter.py    (train/val/test splits)
-                        → data/splits/       (ready for training)
+Raw WAV (from the MCP recorder, or scripts/record_mics.py, or legacy Audacity)
+    → data/raw/ (mic{N}-{origin}-roast{n}.wav, per naming convention)
+        → Label Studio (annotate mic1's first_crack region)
+            → convert_labelstudio_export.py  (per-file JSON annotations)
+                → propagate_annotations.py    (copy mic1 → paired mics)
+                    → chunk_audio.py          (10s WAV chunks)
+                        → dataset_splitter.py (train/val/test splits)
+                            → data/splits/    (ready for training)
 ```
+
+There are three ways raw WAVs land in `data/raw/`. The primary source today is the
+**coffee-roaster-mcp recorder**, which captures every supervised roast
+automatically; `scripts/record_mics.py` is the bench dual-mic flow; and Audacity
+export is the legacy path from the prototype era.
 
 ---
 
-## Step 1 — Export WAV from Audacity
+## Step 1 — Get raw WAVs into `data/raw/`
+
+### 1a. Recordings from the coffee-roaster-mcp recorder (primary source)
+
+During a supervised roast, the `coffee-roaster-mcp` recorder captures audio for
+you (when `recording.enabled` and `recording.autocapture` are set, and after
+`set_recording_metadata` has supplied the origin + roast number). Each roast
+writes a **per-session capture directory** at
+`<export_location>/<session-id>/` — by default
+`<log_dir>/captures/<session-id>/`, which is gitignored so the large WAVs are
+never committed. `<session-id>` is the roast session's run id.
+
+Each session directory contains:
+
+| File | What it is |
+|------|-----------|
+| `mic{N}-{origin}-roast{n}.wav` | One WAV per capture device, 1-based device order. `mic1` is the detector's teed stream. **16 kHz, mono, 16-bit PCM.** |
+| `roast.recording.json` | The recording manifest (schema v2) — see below. |
+| `{origin}-roast{n}-session.json` | An annotation-pipeline session JSON, shape-compatible with `record_mics.py`, so `propagate_annotations.py` (Step 4) reads it directly. |
+
+These WAVs are already at the model's native **16 kHz** (unlike
+`record_mics.py`'s 44.1 kHz), and `chunk_audio.py` resamples internally anyway, so
+they need no special handling: **copy or rename the `mic*.wav` files into
+`data/raw/`** following the naming convention below, and copy the
+`{origin}-roast{n}-session.json` alongside them so annotation propagation works.
+
+The `roast.recording.json` manifest (written by
+`coffee_roaster_mcp.audio._write_recording_sidecar`) has this shape:
+
+```jsonc
+{
+  "schema_version": 2,
+  "session_id": "<run-id>",
+  "recording_started_monotonic_seconds": 1234.56,  // monotonic clock at record start; null if unknown
+  "milestones": {                                   // recording-relative seconds, or null per milestone
+    "first_crack": 512.3,
+    "drop": 640.0
+  },
+  "streams": [                                       // one entry per WAV, device order (index 0 = detector/mic1)
+    {
+      "device": "<device label>",
+      "wav_filename": "mic1-<origin>-roast<n>.wav",
+      "sample_rate": 16000,
+      "channels": 1,
+      "sample_width_bytes": 2,
+      "frame_count": 9600000,
+      "duration_seconds": 600.0
+    }
+    // ...mic2, mic3 as configured
+  ]
+  // The first (detector) stream's fields are also mirrored at the top level
+  // (wav_filename / sample_rate / channels / sample_width_bytes / frame_count /
+  // duration_seconds) as a v1 back-compat convenience.
+}
+```
+
+The manifest is informational for the training pipeline (`chunk_audio.py` and
+`dataset_splitter.py` do not read it); annotation propagation keys on the
+`{origin}-roast{n}-session.json` instead.
+
+### 1b. Recordings from `scripts/record_mics.py` (bench dual-mic)
+
+The dual-mic bench flow records a paired session directly. See
+`docs/multi_mic_setup.md` for the full hardware setup. In brief:
+
+```bash
+python scripts/record_mics.py list-devices
+python scripts/record_mics.py record --origin <bean-slug> --roast-num <n>
+```
+
+Press **Ctrl-C** to stop. This writes, into `data/raw/`:
+
+```
+mic1-<origin>-roast<n>.wav          # detector mic (e.g. FIFINE, ch 0)
+mic2-<origin>-roast<n>.wav          # paired mic (e.g. ATR2100x, ch 1)
+<origin>-roast<n>-session.json      # hardware metadata + the mics list
+```
+
+These WAVs are **44100 Hz**; `chunk_audio.py` resamples to 16 kHz. Sessions
+shorter than 60 s are saved with a `_partial` suffix and excluded by convention.
+The `-session.json` here is the same shape the MCP recorder writes, so Step 4
+propagation works identically.
+
+### 1c. Legacy: Audacity export
+
+The prototype-era recordings were exported by hand from Audacity. Kept for
+reference — new recordings use one of the two flows above.
 
 1. Open your `.aup3` project in Audacity
 2. **File → Export Audio…**
@@ -81,7 +173,7 @@ Only the `first_crack` label is needed. Everything outside annotated regions is 
    - Click and drag on the waveform to draw **one region** from the **first pop** to the **end of consistent cracking**
    - This region typically spans 1–5 minutes of audio
    - You do NOT need to annotate individual pops — one continuous region is correct
-   - The chunking pipeline (Step 4) will slice this into fixed 10-second training windows
+   - The chunking pipeline (Step 5) will slice this into fixed 10-second training windows
 4. Press **Submit** (or Ctrl+Enter) to save the annotation
 5. Move to the next task
 
@@ -116,18 +208,46 @@ python -m coffee_first_crack.data_prep.convert_labelstudio_export \
 
 This produces one `{stem}.json` annotation file per audio file in `data/labels/`.
 
-**Multi-mic recordings:** Only mic1 needs to be annotated in Label Studio (both mics are sample-locked, so timestamps are identical). After converting, propagate annotations to the paired mic2 files:
+For multi-mic sessions, you annotate **mic1 only** in Label Studio; Step 4
+propagates that annotation to the paired mics.
+
+---
+
+## Step 4 — Propagate Annotations to Paired Mics
+
+Multi-mic sessions (from the MCP recorder or `record_mics.py`) capture every mic
+sample-locked, so their first-crack timestamps are identical. Annotate **mic1
+only** in Label Studio, then propagate mic1's converted annotation JSON to every
+paired mic in the session:
 
 ```bash
 python scripts/propagate_annotations.py --dry-run   # preview
-python scripts/propagate_annotations.py              # create mic2 annotation JSONs
+python scripts/propagate_annotations.py              # create mic2..N annotation JSONs
 ```
+
+**How the pairing works.** `propagate_annotations.py` discovers sessions by
+reading the `{origin}-roast{n}-session.json` files in `data/raw` (the
+`--session-dir`). Each session JSON carries `origin`, `roast_num`, `sample_rate`,
+and a `mics` list of `{mic_num, label, file}` entries. The script reads the
+primary mic's annotation JSON (`--primary-mic`, default `1`) from `data/labels`
+and writes an identical annotation JSON — same `annotations`, per-mic
+`audio_file`/`duration` — for every other mic listed in the session. Sessions
+with no paired mics, and mics whose annotation JSON already exists (without
+`--overwrite`), are skipped.
+
+**This is why the `{origin}-roast{n}-session.json` must sit in `data/raw`
+alongside the WAVs** (Step 1). Both the MCP recorder and `record_mics.py` write
+that file in exactly the shape this script expects, so MCP-captured sessions
+propagate automatically — no extra tooling. If a set of paired WAVs has **no**
+session JSON (e.g. hand-assembled from loose files), propagation cannot pair
+them; in that case annotate each mic by hand in Label Studio and run Step 3 per
+file, skipping this step.
 
 See `docs/multi_mic_setup.md` for the full paired-recording workflow.
 
 ---
 
-## Step 4 — Chunk Audio into 10-Second Windows
+## Step 5 — Chunk Audio into 10-Second Windows
 
 ```bash
 python -m coffee_first_crack.data_prep.chunk_audio \
@@ -153,7 +273,7 @@ Chunk filenames encode the source recording and window start time:
 
 ---
 
-## Step 5 — Stratified Train/Val/Test Split
+## Step 6 — Stratified Train/Val/Test Split
 
 ```bash
 python -m coffee_first_crack.data_prep.dataset_splitter \
@@ -176,7 +296,7 @@ data/splits/
 
 ---
 
-## Step 6 — Generate recordings.csv Manifest
+## Step 7 — Generate recordings.csv Manifest
 
 ```bash
 python -c "
@@ -208,13 +328,14 @@ When recording with two microphones, each mic produces an independent WAV file. 
 
 | Source | Mic | Origin | Files | Status |
 |--------|-----|--------|-------|--------|
-| Legacy prototype | mic-1-original | costarica-hermosa | 4 roasts | ✅ Annotated |
-| Legacy prototype | mic-1-original | brazil | 5 roasts | ✅ Annotated |
+| Legacy prototype | mic-1-original | costarica-hermosa | 5 roasts | ✅ Annotated |
+| Legacy prototype | mic-1-original | brazil | 4 roasts | ✅ Annotated |
 | Single-mic recordings | mic-2-new | brazil | 4 roasts | ✅ Annotated |
 | Single-mic recordings | mic-2-new | brazil-santos | 2 roasts | ✅ Annotated |
 | Multi-mic recordings | mic-1-new (fifine) | panama-hortigal-estate | 3 roasts | ✅ Annotated |
 | Multi-mic recordings | mic-2-new (audio-technica) | panama-hortigal-estate | 3 roasts | ✅ Annotated |
 
-**Totals**: 21 recordings → 1,435 chunks (223 first_crack / 1,212 no_first_crack)
+**Totals** (baseline_v5, per `data/splits/split_report.md`): 21 recordings →
+1,435 chunks (223 first_crack / 1,212 no_first_crack).
 
-> When adding new recordings, re-run Steps 3–6 to rebuild the full dataset (the chunker and splitter process all annotation files in `data/labels/`).
+> When adding new recordings, re-run Steps 3–7 to rebuild the full dataset (the chunker and splitter process all annotation files in `data/labels/`).


### PR DESCRIPTION
Docs-only refresh of the data-preparation workflow so the docs match the
established, tested pipeline (the operator is mid-annotation-cycle; this changes
no code, scripts, or data — `.md` files only). Every path/command/number was
verified against the actual repo content and the `coffee-roaster-mcp` recorder
source.

## The four fixes

1. **`docs/data_preparation.md` Step 1 restructured.** The `coffee-roaster-mcp`
   recorder is now documented as the primary raw-WAV source: per-session capture
   directory `<export_location>/<session-id>/` (default
   `<log_dir>/captures/<session-id>/`, gitignored), `mic{N}-{origin}-roast{n}.wav`
   at **16 kHz mono 16-bit**, and the `roast.recording.json` schema-v2 manifest
   shape (documented from `coffee_roaster_mcp.audio._write_recording_sidecar`:
   `schema_version`, `session_id`, `recording_started_monotonic_seconds`,
   `milestones`, `streams[]`). `record_mics.py` (bench dual-mic) and Audacity
   export are demoted to subsections 1b / 1c.

2. **Annotation propagation promoted to its own Step 4.** Documents the pairing
   mechanism as the code actually implements it: `propagate_annotations.py`
   discovers sessions by reading `{origin}-roast{n}-session.json` in `data/raw`
   and copies mic1's annotation to every paired mic. **The MCP recorder writes
   that companion session JSON too** (issue #176, same shape as `record_mics.py`),
   so MCP-captured sessions propagate automatically — no extra tooling. The
   hand-annotate fallback is documented only for the no-session-JSON case.
   Remaining steps renumbered 5 / 6 / 7 (and the in-text Step references fixed).

3. **`data/DATASET_CARD.md` reconciled to baseline_v5.** The stale 15-recording /
   973-chunk / 587-195-191 snapshot is replaced with the current 21 recordings /
   1,435 chunks / 922-210-303, reconciled against `data/splits/split_report.md`;
   the source-recordings table and mic/origin feature lists corrected; a
   "Last updated: 12 Jul 2026 (baseline_v5, 303-sample test set)" line added.

4. **README "Retraining & updating metrics" section added** — the exact
   train → evaluate → `export_onnx --quantize` → `evaluate_onnx` sequence (module
   + console-script entrypoints as they exist), what to update afterwards (README
   metrics + DATASET_CARD), and what is committed vs pushed to HF Hub vs
   gitignored. The stale int8 "not re-benchmarked on baseline_v5" note is replaced
   with the 12 Jul re-bench fact (91.1% P / 97.6% R / F1 0.943, no quality loss)
   plus the re-bench command.

## Notes / audit reconciliation

- The audit's fallback worry — "if MCP captures can't satisfy
  `propagate_annotations.py`, document annotate-both-by-hand" — turned out to be
  moot: the MCP recorder already writes a `propagate`-compatible
  `{origin}-roast{n}-session.json` alongside `roast.recording.json` (#176), so
  MCP captures propagate automatically. Documented that as the happy path;
  hand-annotation is only the no-session-JSON fallback.
- The prior Current-Dataset-Status table had costarica=4 / brazil=5 for the
  legacy mic-1 recordings; `split_report.md` shows costarica=5 (4 `hp-a` + 1
  `.alog`) / brazil=4 (`.alog`). Corrected to match the splits.

Docs-only; the 3 required CI checks (test / lint / torch-free-import) are all
Python and untouched by `.md` edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)